### PR TITLE
Fix 'Add Empty Tunnel...' menu item in macOS

### DIFF
--- a/Sources/WireGuardApp/UI/macOS/View/ConfTextColorTheme.swift
+++ b/Sources/WireGuardApp/UI/macOS/View/ConfTextColorTheme.swift
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
+// Copyright © 2024 Amnezia VPN. All Rights Reserved.
 
 import Cocoa
 
@@ -22,6 +23,15 @@ struct ConfTextAquaColorTheme: ConfTextColorTheme {
         HighlightPort.rawValue: NSColor(hex: "#815F03"), // Attributes in Xcode
         HighlightMTU.rawValue: NSColor(hex: "#1C00CF"), // Numbers in Xcode
         HighlightKeepalive.rawValue: NSColor(hex: "#1C00CF"), // Numbers in Xcode
+        HighlightJc.rawValue: NSColor(hex: "#1C00CF"), // Numbers in Xcode
+        HighlightJmin.rawValue: NSColor(hex: "#1C00CF"), // Numbers in Xcode
+        HighlightJmax.rawValue: NSColor(hex: "#1C00CF"), // Numbers in Xcode
+        HighlightS1.rawValue: NSColor(hex: "#1C00CF"), // Numbers in Xcode
+        HighlightS2.rawValue: NSColor(hex: "#1C00CF"), // Numbers in Xcode
+        HighlightH1.rawValue: NSColor(hex: "#1C00CF"), // Numbers in Xcode
+        HighlightH2.rawValue: NSColor(hex: "#1C00CF"), // Numbers in Xcode
+        HighlightH3.rawValue: NSColor(hex: "#1C00CF"), // Numbers in Xcode
+        HighlightH4.rawValue: NSColor(hex: "#1C00CF"), // Numbers in Xcode
         HighlightComment.rawValue: NSColor(hex: "#536579"), // Comments in Xcode
         HighlightError.rawValue: NSColor(hex: "#C41A16") // Strings in Xcode
     ]
@@ -41,6 +51,15 @@ struct ConfTextDarkAquaColorTheme: ConfTextColorTheme {
         HighlightPort.rawValue: NSColor(hex: "#75B492"), // Attributes in Xcode
         HighlightMTU.rawValue: NSColor(hex: "#9686F5"), // Numbers in Xcode
         HighlightKeepalive.rawValue: NSColor(hex: "#9686F5"), // Numbers in Xcode
+        HighlightJc.rawValue: NSColor(hex: "#9686F5"), // Numbers in Xcode
+        HighlightJmin.rawValue: NSColor(hex: "#9686F5"), // Numbers in Xcode
+        HighlightJmax.rawValue: NSColor(hex: "#9686F5"), // Numbers in Xcode
+        HighlightS1.rawValue: NSColor(hex: "#9686F5"), // Numbers in Xcode
+        HighlightS2.rawValue: NSColor(hex: "#9686F5"), // Numbers in Xcode
+        HighlightH1.rawValue: NSColor(hex: "#9686F5"), // Numbers in Xcode
+        HighlightH2.rawValue: NSColor(hex: "#9686F5"), // Numbers in Xcode
+        HighlightH3.rawValue: NSColor(hex: "#9686F5"), // Numbers in Xcode
+        HighlightH4.rawValue: NSColor(hex: "#9686F5"), // Numbers in Xcode
         HighlightComment.rawValue: NSColor(hex: "#6C7986"), // Comments in Xcode
         HighlightError.rawValue: NSColor(hex: "#FF4C4C") // Strings in Xcode
     ]

--- a/Sources/WireGuardApp/UI/macOS/View/ConfTextStorage.swift
+++ b/Sources/WireGuardApp/UI/macOS/View/ConfTextStorage.swift
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
+// Copyright © 2024 Amnezia VPN. All Rights Reserved.
 
 import Cocoa
 
@@ -40,7 +41,11 @@ class ConfTextStorage: NSTextStorage {
             return [.font: boldFont]
         case HighlightPublicKey.rawValue, HighlightPrivateKey.rawValue, HighlightPresharedKey.rawValue,
              HighlightIP.rawValue, HighlightCidr.rawValue, HighlightHost.rawValue, HighlightPort.rawValue,
-             HighlightMTU.rawValue, HighlightKeepalive.rawValue, HighlightDelimiter.rawValue:
+             HighlightMTU.rawValue, HighlightKeepalive.rawValue,
+             HighlightJc.rawValue, HighlightJmin.rawValue, HighlightJmax.rawValue,
+             HighlightS1.rawValue, HighlightS2.rawValue,
+             HighlightH1.rawValue, HighlightH2.rawValue, HighlightH3.rawValue, HighlightH4.rawValue,
+             HighlightDelimiter.rawValue:
             return [.font: defaultFont]
         case HighlightComment.rawValue:
             return [.font: italicFont]

--- a/Sources/WireGuardApp/UI/macOS/View/highlighter.c
+++ b/Sources/WireGuardApp/UI/macOS/View/highlighter.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 /*
  * Copyright (C) 2015-2020 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
+ * Copyright (C) 2024 Amnezia VPN. All Rights Reserved.
  */
 
 #include <stdbool.h>
@@ -221,6 +222,21 @@ static bool is_valid_persistentkeepalive(string_span_t s)
 	return is_valid_uint(s, false, 0, 65535);
 }
 
+static bool is_valid_jc(string_span_t s)
+{
+	return is_valid_uint(s, false, 0, 65535);
+}
+
+static bool is_valid_junk_size(string_span_t s)
+{
+	return is_valid_uint(s, false, 0, 65535);
+}
+
+static bool is_valid_magic_header(string_span_t s)
+{
+	return is_valid_uint(s, false, 0, 4294967295);
+}
+
 #ifndef MOBILE_WGQUICK_SUBSET
 
 static bool is_valid_fwmark(string_span_t s)
@@ -344,6 +360,15 @@ enum field {
 	Address,
 	DNS,
 	MTU,
+	Jc,
+	Jmin,
+	Jmax,
+	S1,
+	S2,
+	H1,
+	H2,
+	H3,
+	H4,
 #ifndef MOBILE_WGQUICK_SUBSET
 	FwMark,
 	Table,
@@ -383,6 +408,15 @@ static enum field get_field(string_span_t s)
 	check_enum(AllowedIPs);
 	check_enum(Endpoint);
 	check_enum(PersistentKeepalive);
+	check_enum(Jc);
+	check_enum(Jmin);
+	check_enum(Jmax);
+	check_enum(S1);
+	check_enum(S2);
+	check_enum(H1);
+	check_enum(H2);
+	check_enum(H3);
+	check_enum(H4);
 #ifndef MOBILE_WGQUICK_SUBSET
 	check_enum(FwMark);
 	check_enum(Table);
@@ -521,6 +555,33 @@ static void highlight_value(struct highlight_span_array *ret, const string_span_
 		break;
 	case MTU:
 		append_highlight_span(ret, parent.s, s, is_valid_mtu(s) ? HighlightMTU : HighlightError);
+		break;
+	case Jc:
+		append_highlight_span(ret, parent.s, s, is_valid_jc(s) ? HighlightJc : HighlightError);
+		break;
+	case Jmin:
+		append_highlight_span(ret, parent.s, s, is_valid_junk_size(s) ? HighlightJmin : HighlightError);
+		break;
+	case Jmax:
+		append_highlight_span(ret, parent.s, s, is_valid_junk_size(s) ? HighlightJmax : HighlightError);
+		break;
+	case S1:
+		append_highlight_span(ret, parent.s, s, is_valid_junk_size(s) ? HighlightS1 : HighlightError);
+		break;
+	case S2:
+		append_highlight_span(ret, parent.s, s, is_valid_junk_size(s) ? HighlightS2 : HighlightError);
+		break;
+	case H1:
+		append_highlight_span(ret, parent.s, s, is_valid_magic_header(s) ? HighlightH1 : HighlightError);
+		break;
+	case H2:
+		append_highlight_span(ret, parent.s, s, is_valid_magic_header(s) ? HighlightH2 : HighlightError);
+		break;
+	case H3:
+		append_highlight_span(ret, parent.s, s, is_valid_magic_header(s) ? HighlightH3 : HighlightError);
+		break;
+	case H4:
+		append_highlight_span(ret, parent.s, s, is_valid_magic_header(s) ? HighlightH4 : HighlightError);
 		break;
 #ifndef MOBILE_WGQUICK_SUBSET
 	case SaveConfig:

--- a/Sources/WireGuardApp/UI/macOS/View/highlighter.h
+++ b/Sources/WireGuardApp/UI/macOS/View/highlighter.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 /*
  * Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
+ * Copyright (C) 2024 Amnezia VPN. All Rights Reserved.
  */
 
 #include <sys/types.h>
@@ -19,6 +20,15 @@ enum highlight_type {
 	HighlightMTU,
 	HighlightKeepalive,
 	HighlightComment,
+	HighlightJc,
+	HighlightJmin,
+	HighlightJmax,
+	HighlightS1,
+	HighlightS2,
+	HighlightH1,
+	HighlightH2,
+	HighlightH3,
+	HighlightH4,
 	HighlightDelimiter,
 #ifndef MOBILE_WGQUICK_SUBSET
 	HighlightTable,


### PR DESCRIPTION
Added highlighting for advanced security fields.