### PR TITLE
highlighter.c: add awg params

### DIFF
--- a/Sources/WireGuardApp/UI/macOS/View/highlighter.c
+++ b/Sources/WireGuardApp/UI/macOS/View/highlighter.c
@@ -214,11 +214,16 @@ static bool is_valid_mtu(string_span_t s)
 	return is_valid_uint(s, false, 576, 65535);
 }
 
+static bool is_valid_uint16(string_span_t s)
+{
+	return is_valid_uint(s, false, 0, 65535);
+}
+
 static bool is_valid_persistentkeepalive(string_span_t s)
 {
 	if (is_same(s, "off"))
 		return true;
-	return is_valid_uint(s, false, 0, 65535);
+	return is_valid_uint16(s);
 }
 
 #ifndef MOBILE_WGQUICK_SUBSET
@@ -344,6 +349,22 @@ enum field {
 	Address,
 	DNS,
 	MTU,
+	Jc,
+	Jmin,
+	Jmax,
+	S1,
+	S2,
+	S3,
+	S4,
+	H1,
+	H2,
+	H3,
+	H4,
+	I1,
+	I2,
+	I3,
+	I4,
+	I5,
 #ifndef MOBILE_WGQUICK_SUBSET
 	FwMark,
 	Table,
@@ -378,6 +399,22 @@ static enum field get_field(string_span_t s)
 	check_enum(Address);
 	check_enum(DNS);
 	check_enum(MTU);
+	check_enum(Jc);
+	check_enum(Jmin);
+	check_enum(Jmax);
+	check_enum(S1);
+	check_enum(S2);
+	check_enum(S3);
+	check_enum(S4);
+	check_enum(H1);
+	check_enum(H2);
+	check_enum(H3);
+	check_enum(H4);
+	check_enum(I1);
+	check_enum(I2);
+	check_enum(I3);
+	check_enum(I4);
+	check_enum(I5);
 	check_enum(PublicKey);
 	check_enum(PresharedKey);
 	check_enum(AllowedIPs);
@@ -521,6 +558,26 @@ static void highlight_value(struct highlight_span_array *ret, const string_span_
 		break;
 	case MTU:
 		append_highlight_span(ret, parent.s, s, is_valid_mtu(s) ? HighlightMTU : HighlightError);
+		break;
+	case Jc:
+	case Jmin:
+	case Jmax:
+	case S1:
+	case S2:
+	case S3:
+	case S4:
+		append_highlight_span(ret, parent.s, s, is_valid_uint16(s) ? HighlightMTU : HighlightError);
+		break;
+	case H1:
+	case H2:
+	case H3:
+	case H4:
+	case I1:
+	case I2:
+	case I3:
+	case I4:
+	case I5:
+		append_highlight_span(ret, parent.s, s, HighlightMTU);
 		break;
 #ifndef MOBILE_WGQUICK_SUBSET
 	case SaveConfig:


### PR DESCRIPTION
Fixes not being able to save new from-scratch configurations on macOS if they have awg params since they would be marked as invalid/unknown fields