### PR TITLE
feat: add Salamander ObfsPSK support

### DIFF
--- a/Sources/Shared/Model/TunnelConfiguration+WgQuickConfig.swift
+++ b/Sources/Shared/Model/TunnelConfiguration+WgQuickConfig.swift
@@ -21,6 +21,7 @@ extension TunnelConfiguration {
         case interfaceHasInvalidAddress(String)
         case interfaceHasInvalidDNS(String)
         case interfaceHasInvalidMTU(String)
+        case interfaceHasInvalidPreSharedKey(String)
         case interfaceHasUnrecognizedKey(String)
         case interfaceHasInvalidCustomParam(String)
         case peerHasNoPublicKey
@@ -186,6 +187,9 @@ extension TunnelConfiguration {
         if let transportPacketMagicHeader = interface.transportPacketMagicHeader {
             output.append("H4 = \(transportPacketMagicHeader)\n")
         }
+        if let obfsPSK = interface.obfsPSK {
+            output.append("ObfsPSK = \(obfsPSK.base64Key)\n")
+        }
         if let specialJunk1 = interface.specialJunk1 {
             output.append("I1 = \(specialJunk1)\n")
         }
@@ -332,6 +336,12 @@ extension TunnelConfiguration {
         }
         if let transportPacketMagicHeaderString = attributes["h4"] {
             interface.transportPacketMagicHeader = transportPacketMagicHeaderString
+        }
+        if let obfsPSKString = attributes["obfspsk"] {
+            guard let obfsPSK = PreSharedKey(base64Key: obfsPSKString) else {
+                throw ParseError.interfaceHasInvalidPreSharedKey(obfsPSKString)
+            }
+            interface.obfsPSK = obfsPSK
         }
         if let specialJunk1String = attributes["i1"] {
             interface.specialJunk1 = specialJunk1String

--- a/Sources/WireGuardApp/Tunnel/TunnelConfiguration+UapiConfig.swift
+++ b/Sources/WireGuardApp/Tunnel/TunnelConfiguration+UapiConfig.swift
@@ -41,7 +41,7 @@ extension TunnelConfiguration {
                 }
             }
 
-            let interfaceSectionKeys: Set<String> = ["private_key", "listen_port", "fwmark"]
+            let interfaceSectionKeys: Set<String> = ["private_key", "listen_port", "fwmark", "obfs_psk"]
             let peerSectionKeys: Set<String> = ["public_key", "preshared_key", "allowed_ip", "endpoint", "persistent_keepalive_interval", "last_handshake_time_sec", "last_handshake_time_nsec", "rx_bytes", "tx_bytes", "protocol_version"]
 
             if parserState == .inInterfaceSection {
@@ -87,6 +87,7 @@ extension TunnelConfiguration {
         interfaceConfiguration?.responsePacketMagicHeader = base?.interface.responsePacketMagicHeader
         interfaceConfiguration?.underloadPacketMagicHeader = base?.interface.underloadPacketMagicHeader
         interfaceConfiguration?.transportPacketMagicHeader = base?.interface.transportPacketMagicHeader
+        interfaceConfiguration?.obfsPSK = base?.interface.obfsPSK ?? interfaceConfiguration?.obfsPSK
         interfaceConfiguration?.cookieReplyPacketJunkSize = base?.interface.cookieReplyPacketJunkSize
         interfaceConfiguration?.transportPacketJunkSize = base?.interface.transportPacketJunkSize
         interfaceConfiguration?.specialJunk1 = base?.interface.specialJunk1
@@ -117,6 +118,12 @@ extension TunnelConfiguration {
             if listenPort != 0 {
                 interface.listenPort = listenPort
             }
+        }
+        if let obfsPSKString = attributes["obfs_psk"] {
+            guard let obfsPSK = PreSharedKey(hexKey: obfsPSKString) else {
+                throw ParseError.interfaceHasInvalidPreSharedKey(obfsPSKString)
+            }
+            interface.obfsPSK = obfsPSK
         }
         return interface
     }

--- a/Sources/WireGuardApp/Tunnel/TunnelConfiguration+UapiConfig.swift
+++ b/Sources/WireGuardApp/Tunnel/TunnelConfiguration+UapiConfig.swift
@@ -74,6 +74,8 @@ extension TunnelConfiguration {
             throw ParseError.multiplePeersWithSamePublicKey
         }
 
+        let existingObfsPSK = interfaceConfiguration?.obfsPSK
+
         interfaceConfiguration?.addresses = base?.interface.addresses ?? []
         interfaceConfiguration?.dns = base?.interface.dns ?? []
         interfaceConfiguration?.dnsSearch = base?.interface.dnsSearch ?? []
@@ -87,7 +89,7 @@ extension TunnelConfiguration {
         interfaceConfiguration?.responsePacketMagicHeader = base?.interface.responsePacketMagicHeader
         interfaceConfiguration?.underloadPacketMagicHeader = base?.interface.underloadPacketMagicHeader
         interfaceConfiguration?.transportPacketMagicHeader = base?.interface.transportPacketMagicHeader
-        interfaceConfiguration?.obfsPSK = base?.interface.obfsPSK ?? interfaceConfiguration?.obfsPSK
+        interfaceConfiguration?.obfsPSK = base?.interface.obfsPSK ?? existingObfsPSK
         interfaceConfiguration?.cookieReplyPacketJunkSize = base?.interface.cookieReplyPacketJunkSize
         interfaceConfiguration?.transportPacketJunkSize = base?.interface.transportPacketJunkSize
         interfaceConfiguration?.specialJunk1 = base?.interface.specialJunk1

--- a/Sources/WireGuardApp/UI/TunnelViewModel.swift
+++ b/Sources/WireGuardApp/UI/TunnelViewModel.swift
@@ -24,6 +24,7 @@ class TunnelViewModel {
         case responsePacketMagicHeader
         case underloadPacketMagicHeader
         case transportPacketMagicHeader
+        case obfsPSK
         case cookieReplyPacketJunkSize
         case transportPacketJunkSize
         case specialJunk1
@@ -53,6 +54,7 @@ class TunnelViewModel {
             case .responsePacketMagicHeader: return tr("H2")
             case .underloadPacketMagicHeader: return tr("H3")
             case .transportPacketMagicHeader: return tr("H4")
+            case .obfsPSK: return tr("ObfsPSK")
             case .cookieReplyPacketJunkSize: return tr("S3")
             case .transportPacketJunkSize: return tr("S4")
             case .specialJunk1: return tr("I1")
@@ -216,6 +218,10 @@ class TunnelViewModel {
                 scratchpad[.transportPacketMagicHeader] = String(transportPacketMagicHeader)
             }
 
+            if let obfsPSK = config.obfsPSK {
+                scratchpad[.obfsPSK] = obfsPSK.base64Key
+            }
+
             if let cookieReplyPacketJunkSize = config.cookieReplyPacketJunkSize {
                 scratchpad[.cookieReplyPacketJunkSize] = String(cookieReplyPacketJunkSize)
             }
@@ -367,6 +373,15 @@ class TunnelViewModel {
 
             if let transportPacketMagicHeaderString = scratchpad[.transportPacketMagicHeader], !transportPacketMagicHeaderString.isEmpty {
                 config.transportPacketMagicHeader = transportPacketMagicHeaderString
+            }
+
+            if let obfsPSKString = scratchpad[.obfsPSK], !obfsPSKString.isEmpty {
+                if let obfsPSK = PreSharedKey(base64Key: obfsPSKString) {
+                    config.obfsPSK = obfsPSK
+                } else {
+                    fieldsWithError.insert(.obfsPSK)
+                    errorMessages.append(tr("alertInvalidPeerMessagePreSharedKeyInvalid"))
+                }
             }
 
             if let cookieReplyPacketJunkSizeString = scratchpad[.cookieReplyPacketJunkSize], !cookieReplyPacketJunkSizeString.isEmpty {

--- a/Sources/WireGuardApp/UI/iOS/ViewController/TunnelDetailTableViewController.swift
+++ b/Sources/WireGuardApp/UI/iOS/ViewController/TunnelDetailTableViewController.swift
@@ -19,6 +19,7 @@ class TunnelDetailTableViewController: UITableViewController {
         .junkPacketCount, .junkPacketMinSize, .junkPacketMaxSize,
         .initPacketJunkSize, .responsePacketJunkSize, .cookieReplyPacketJunkSize, .transportPacketJunkSize,
         .initPacketMagicHeader, .responsePacketMagicHeader, .underloadPacketMagicHeader, .transportPacketMagicHeader,
+        .obfsPSK,
         .specialJunk1, .specialJunk2, .specialJunk3, .specialJunk4, .specialJunk5
     ]
 

--- a/Sources/WireGuardApp/UI/iOS/ViewController/TunnelEditTableViewController.swift
+++ b/Sources/WireGuardApp/UI/iOS/ViewController/TunnelEditTableViewController.swift
@@ -38,7 +38,7 @@ class TunnelEditTableViewController: UITableViewController {
         [.junkPacketCount, .junkPacketMinSize, .junkPacketMaxSize,
          .initPacketJunkSize, .responsePacketJunkSize, .cookieReplyPacketJunkSize, .transportPacketJunkSize,
          .initPacketMagicHeader, .responsePacketMagicHeader, .underloadPacketMagicHeader, .transportPacketMagicHeader,
-         .specialJunk1, .specialJunk2, .specialJunk3, .specialJunk4, .specialJunk5]
+         .obfsPSK, .specialJunk1, .specialJunk2, .specialJunk3, .specialJunk4, .specialJunk5]
     ]
 
     let peerFields: [TunnelViewModel.PeerField] = [
@@ -262,7 +262,7 @@ extension TunnelEditTableViewController {
             cell.keyboardType = .numberPad
         case .initPacketMagicHeader, .responsePacketMagicHeader, .underloadPacketMagicHeader, .transportPacketMagicHeader:
             cell.keyboardType = .numbersAndPunctuation
-        case .specialJunk1, .specialJunk2, .specialJunk3, .specialJunk4, .specialJunk5:
+        case .obfsPSK, .specialJunk1, .specialJunk2, .specialJunk3, .specialJunk4, .specialJunk5:
             cell.keyboardType = .default
         }
 

--- a/Sources/WireGuardApp/UI/macOS/ParseError+WireGuardAppError.swift
+++ b/Sources/WireGuardApp/UI/macOS/ParseError+WireGuardAppError.swift
@@ -27,6 +27,8 @@ extension TunnelConfiguration.ParseError: WireGuardAppError {
             return (tr(format: "macAlertDNSInvalid (%@)", value), tr("alertInvalidInterfaceMessageDNSInvalid"))
         case .interfaceHasInvalidMTU(let value):
             return (tr(format: "macAlertMTUInvalid (%@)", value), tr("alertInvalidInterfaceMessageMTUInvalid"))
+        case .interfaceHasInvalidPreSharedKey:
+            return (tr("macAlertPreSharedKeyInvalid"), tr("alertInvalidPeerMessagePreSharedKeyInvalid"))
         case .interfaceHasUnrecognizedKey(let value):
             return (tr(format: "macAlertUnrecognizedInterfaceKey (%@)", value), tr("macAlertInfoUnrecognizedInterfaceKey"))
         case .peerHasNoPublicKey:

--- a/Sources/WireGuardApp/UI/macOS/ViewController/TunnelDetailTableViewController.swift
+++ b/Sources/WireGuardApp/UI/macOS/ViewController/TunnelDetailTableViewController.swift
@@ -39,6 +39,7 @@ class TunnelDetailTableViewController: NSViewController {
         .junkPacketCount, .junkPacketMinSize, .junkPacketMaxSize,
         .initPacketJunkSize, .responsePacketJunkSize, .cookieReplyPacketJunkSize, .transportPacketJunkSize,
         .initPacketMagicHeader, .responsePacketMagicHeader, .underloadPacketMagicHeader, .transportPacketMagicHeader,
+        .obfsPSK,
         .specialJunk1, .specialJunk2, .specialJunk3, .specialJunk4, .specialJunk5
     ]
 

--- a/Sources/WireGuardKit/InterfaceConfiguration.swift
+++ b/Sources/WireGuardKit/InterfaceConfiguration.swift
@@ -18,6 +18,7 @@ public struct InterfaceConfiguration {
     public var responsePacketMagicHeader: String?
     public var underloadPacketMagicHeader: String?
     public var transportPacketMagicHeader: String?
+    public var obfsPSK: PreSharedKey?
     public var listenPort: UInt16?
     public var mtu: UInt16?
     public var dns = [DNSServer]()
@@ -55,6 +56,7 @@ extension InterfaceConfiguration: Equatable {
             lhs.responsePacketMagicHeader == rhs.responsePacketMagicHeader &&
             lhs.underloadPacketMagicHeader == rhs.underloadPacketMagicHeader &&
             lhs.transportPacketMagicHeader == rhs.transportPacketMagicHeader &&
+            lhs.obfsPSK == rhs.obfsPSK &&
             lhs.specialJunk1 == rhs.specialJunk1 &&
             lhs.specialJunk2 == rhs.specialJunk2 &&
             lhs.specialJunk3 == rhs.specialJunk3 &&

--- a/Sources/WireGuardKit/PacketTunnelSettingsGenerator.swift
+++ b/Sources/WireGuardKit/PacketTunnelSettingsGenerator.swift
@@ -81,6 +81,9 @@ class PacketTunnelSettingsGenerator {
         if let transportPacketMagicHeader = tunnelConfiguration.interface.transportPacketMagicHeader {
             wgSettings.append("h4=\(transportPacketMagicHeader)\n")
         }
+        if let obfsPSK = tunnelConfiguration.interface.obfsPSK {
+            wgSettings.append("obfs_psk=\(obfsPSK.hexKey)\n")
+        }
         if let specialJunk1 = tunnelConfiguration.interface.specialJunk1 {
             wgSettings.append("i1=\(specialJunk1)\n")
         }

--- a/Sources/WireGuardKitGo/go.mod
+++ b/Sources/WireGuardKitGo/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/amnezia-vpn/amnezia-libxray v1.0.0
 	github.com/amnezia-vpn/amnezia-xray-core v1.260206.0
-	github.com/amnezia-vpn/amneziawg-go v0.2.18
+	github.com/amnezia-vpn/amneziawg-go v0.2.19-0.20260615103050-21028ef1e5ec
 	golang.org/x/sys v0.41.0
 )
 
@@ -49,3 +49,5 @@ require (
 	gvisor.dev/gvisor v0.0.0-20260122175437-89a5d21be8f0 // indirect
 	lukechampine.com/blake3 v1.4.1 // indirect
 )
+
+replace github.com/amnezia-vpn/amneziawg-go => github.com/yaroslav-ulta/amneziawg-go v0.2.19-0.20260615103050-21028ef1e5ec

--- a/Sources/WireGuardKitGo/go.sum
+++ b/Sources/WireGuardKitGo/go.sum
@@ -4,6 +4,8 @@ github.com/amnezia-vpn/amnezia-xray-core v1.260206.0 h1:6Y/gIluyFNsqFlAPEl+YP4UT
 github.com/amnezia-vpn/amnezia-xray-core v1.260206.0/go.mod h1:xf2m+NVTVda+ESVqweCRkLwoazQIw1g5e9orsYqeFMk=
 github.com/amnezia-vpn/amneziawg-go v0.2.18 h1:pUn7/P8qdGmHd6JmE3bCQXPblZs3vruWR98nLODQLJg=
 github.com/amnezia-vpn/amneziawg-go v0.2.18/go.mod h1:aMgOk9MuX0xI7b5TKAYp8pLM54RlXcOPzDvYw3YEO5A=
+github.com/yaroslav-ulta/amneziawg-go v0.2.19-0.20260615103050-21028ef1e5ec h1:jgXbNnWn7/uKQyh5X7MDjwbnj6IgL5a+1Hd2H9jRNFI=
+github.com/yaroslav-ulta/amneziawg-go v0.2.19-0.20260615103050-21028ef1e5ec/go.mod h1:aMgOk9MuX0xI7b5TKAYp8pLM54RlXcOPzDvYw3YEO5A=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/apernet/quic-go v0.57.2-0.20260111184307-eec823306178 h1:bSq8n+gX4oO/qnM3MKf4kroW75n+phO9Qp6nigJKZ1E=


### PR DESCRIPTION
## Summary
- parse/export ObfsPSK in wg-quick configs
- pass obfs_psk into UAPI settings and preserve it when reading runtime UAPI configs
- expose ObfsPSK in iOS/macOS tunnel view/edit UI
- temporarily point WireGuardKitGo at yaroslav-ulta/amneziawg-go pseudo-version pending amnezia-vpn/amneziawg-go#147

## Validation
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift build
- Lima AWG2 E2E with kernel ulta-plus/vpnn-master, ObfsPSK tools, and amneziawg-go PR branch: tunnel ping both directions, external ping through tunnel, parallel site fetches, 10MB throughput download, fallback video download

Note: YouTube egress is currently refused from both host and Lima VM before the tunnel, so the YouTube-specific download was recorded as environment-blocked while the tunnel throughput/video fallback passed.