### PR TITLE
Refactor: Use unified app group identifier build configuration setting.

### DIFF
--- a/Sources/WireGuardApp/Config/Config.xcconfig
+++ b/Sources/WireGuardApp/Config/Config.xcconfig
@@ -1,2 +1,5 @@
 #include "Version.xcconfig"
-#include "Developer.xcconfig"
+#include? "Developer.xcconfig"
+
+APP_GROUP_IDENTIFIER=group.$(APP_ID_IOS)
+APP_GROUP_IDENTIFIER[sdk=macosx*]=$(DEVELOPMENT_TEAM).group.$(APP_ID_MACOS)

--- a/Sources/WireGuardApp/UI/iOS/Info.plist
+++ b/Sources/WireGuardApp/UI/iOS/Info.plist
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
@@ -44,7 +43,7 @@
 		</dict>
 		<dict>
 			<key>CFBundleTypeIconFiles</key>
-			<array />
+			<array/>
 			<key>CFBundleTypeName</key>
 			<string>Text file</string>
 			<key>CFBundleTypeRole</key>
@@ -72,11 +71,11 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
-	<false />
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
-	<true />
+	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
-	<false />
+	<false/>
 	<key>NSCameraUsageDescription</key>
 	<string>Localized</string>
 	<key>NSFaceIDUsageDescription</key>
@@ -84,7 +83,7 @@
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
-	<array />
+	<array/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -122,6 +121,6 @@
 		</dict>
 	</array>
 	<key>com.wireguard.ios.app_group_id</key>
-	<string>group.$(APP_ID_IOS)</string>
+	<string>$(APP_GROUP_IDENTIFIER)</string>
 </dict>
 </plist>

--- a/Sources/WireGuardApp/UI/macOS/Info.plist
+++ b/Sources/WireGuardApp/UI/macOS/Info.plist
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
@@ -27,7 +26,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconFile</key>
-	<string />
+	<string></string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -41,15 +40,15 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
-	<false />
+	<false/>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSMultipleInstancesProhibited</key>
-	<true />
+	<true/>
 	<key>LSUIElement</key>
-	<true />
+	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
 
@@ -77,6 +76,6 @@ Copyright © 2024 Amnezia. All Rights Reserved.</string>
 		</dict>
 	</array>
 	<key>com.wireguard.macos.app_group_id</key>
-	<string>$(DEVELOPMENT_TEAM).group.$(APP_ID_MACOS)</string>
+	<string>$(APP_GROUP_IDENTIFIER)</string>
 </dict>
 </plist>

--- a/Sources/WireGuardApp/UI/macOS/LoginItemHelper/Info.plist
+++ b/Sources/WireGuardApp/UI/macOS/LoginItemHelper/Info.plist
@@ -1,16 +1,15 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>ITSAppUsesNonExemptEncryption</key>
-	<false />
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconFile</key>
-	<string />
+	<string></string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -30,10 +29,10 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>LSBackgroundOnly</key>
-	<true />
+	<true/>
 	<key>com.wireguard.macos.app_id</key>
 	<string>$(APP_ID_MACOS)</string>
 	<key>com.wireguard.macos.app_group_id</key>
-	<string>$(DEVELOPMENT_TEAM).group.$(APP_ID_MACOS)</string>
+	<string>$(APP_GROUP_IDENTIFIER)</string>
 </dict>
 </plist>

--- a/Sources/WireGuardApp/UI/macOS/LoginItemHelper/LoginItemHelper.entitlements
+++ b/Sources/WireGuardApp/UI/macOS/LoginItemHelper/LoginItemHelper.entitlements
@@ -6,7 +6,7 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>$(DEVELOPMENT_TEAM).group.$(APP_ID_MACOS)</string>
+		<string>$(APP_GROUP_IDENTIFIER)</string>
 	</array>
 </dict>
 </plist>

--- a/Sources/WireGuardApp/UI/macOS/WireGuard.entitlements
+++ b/Sources/WireGuardApp/UI/macOS/WireGuard.entitlements
@@ -10,7 +10,7 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>$(DEVELOPMENT_TEAM).group.$(APP_ID_MACOS)</string>
+		<string>$(APP_GROUP_IDENTIFIER)</string>
 	</array>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>

--- a/Sources/WireGuardNetworkExtension/Info.plist
+++ b/Sources/WireGuardNetworkExtension/Info.plist
@@ -1,10 +1,7 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false />
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -23,6 +20,10 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>
@@ -31,10 +32,8 @@
 		<string>$(PRODUCT_MODULE_NAME).PacketTunnelProvider</string>
 	</dict>
 	<key>com.wireguard.ios.app_group_id</key>
-	<string>group.$(APP_ID_IOS)</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<string>$(APP_GROUP_IDENTIFIER)</string>
 	<key>com.wireguard.macos.app_group_id</key>
-	<string>$(DEVELOPMENT_TEAM).group.$(APP_ID_MACOS)</string>
+	<string>$(APP_GROUP_IDENTIFIER)</string>
 </dict>
 </plist>

--- a/Sources/WireGuardNetworkExtension/WireGuardNetworkExtension_iOS.entitlements
+++ b/Sources/WireGuardNetworkExtension/WireGuardNetworkExtension_iOS.entitlements
@@ -8,7 +8,7 @@
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.$(APP_ID_IOS)</string>
+		<string>$(APP_GROUP_IDENTIFIER)</string>
 	</array>
 </dict>
 </plist>

--- a/Sources/WireGuardNetworkExtension/WireGuardNetworkExtension_macOS.entitlements
+++ b/Sources/WireGuardNetworkExtension/WireGuardNetworkExtension_macOS.entitlements
@@ -10,7 +10,7 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>$(DEVELOPMENT_TEAM).group.$(APP_ID_MACOS)</string>
+		<string>$(APP_GROUP_IDENTIFIER)</string>
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>


### PR DESCRIPTION
## 📝 What was done

This PR refactors how the App Group Identifier is managed. Instead of hardcoding the ID or scattering it across different files, everything is now moved into a single, unified build configuration setting.
Both the main app and the network extension now pull the identical App Group ID automatically. This fixes configuration clutter and makes it much easier to rebrand or use custom identifiers for AmneziaWG builds.

## ⚙️ Key Changes

* Moved the App Group ID into a shared build configuration variable.
* Updated .entitlements files to resolve the group identifier dynamically.
* Refactored shared container initialization code in both the main app and the tunnel target to use this new unified setting.
* Cleaned up old hardcoded string constants.