### PR TITLE
Refactor: Use folders instead of groups.

### DIFF
--- a/WireGuard.xcodeproj/project.pbxproj
+++ b/WireGuard.xcodeproj/project.pbxproj
@@ -3,215 +3,21 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 73;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4E29B1C32BC1222C00824F53 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 4E29B1C22BC1222C00824F53 /* InfoPlist.xcstrings */; };
-		4E5C5B942BA6367F00082DED /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 4E5C5B932BA6367F00082DED /* PrivacyInfo.xcprivacy */; };
-		4E5C5B962BA636B300082DED /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 4E5C5B952BA636B300082DED /* PrivacyInfo.xcprivacy */; };
-		4E9BD26F2BC12AAB00D71616 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 4E9BD26E2BC12AAB00D71616 /* Localizable.xcstrings */; };
-		4E9BD2702BC12AAB00D71616 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 4E9BD26E2BC12AAB00D71616 /* Localizable.xcstrings */; };
-		58233BCF2591F842002060A8 /* NotificationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58233BCE2591F842002060A8 /* NotificationToken.swift */; };
-		58233BD02591F842002060A8 /* NotificationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58233BCE2591F842002060A8 /* NotificationToken.swift */; };
-		585B105A2577E293004F691E /* InterfaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10462577E293004F691E /* InterfaceConfiguration.swift */; };
-		585B105B2577E293004F691E /* InterfaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10462577E293004F691E /* InterfaceConfiguration.swift */; };
-		585B105C2577E293004F691E /* InterfaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10462577E293004F691E /* InterfaceConfiguration.swift */; };
-		585B105D2577E293004F691E /* InterfaceConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10462577E293004F691E /* InterfaceConfiguration.swift */; };
-		585B105E2577E293004F691E /* PeerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10472577E293004F691E /* PeerConfiguration.swift */; };
-		585B105F2577E293004F691E /* PeerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10472577E293004F691E /* PeerConfiguration.swift */; };
-		585B10602577E293004F691E /* PeerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10472577E293004F691E /* PeerConfiguration.swift */; };
-		585B10612577E293004F691E /* PeerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10472577E293004F691E /* PeerConfiguration.swift */; };
-		585B10622577E293004F691E /* DNSServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10482577E293004F691E /* DNSServer.swift */; };
-		585B10632577E293004F691E /* DNSServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10482577E293004F691E /* DNSServer.swift */; };
-		585B10642577E294004F691E /* DNSServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10482577E293004F691E /* DNSServer.swift */; };
-		585B10652577E294004F691E /* DNSServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10482577E293004F691E /* DNSServer.swift */; };
-		585B10662577E294004F691E /* TunnelConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10492577E293004F691E /* TunnelConfiguration.swift */; };
-		585B10672577E294004F691E /* TunnelConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10492577E293004F691E /* TunnelConfiguration.swift */; };
-		585B10682577E294004F691E /* TunnelConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10492577E293004F691E /* TunnelConfiguration.swift */; };
-		585B10692577E294004F691E /* TunnelConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10492577E293004F691E /* TunnelConfiguration.swift */; };
-		585B106F2577E294004F691E /* WireGuardAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B104B2577E293004F691E /* WireGuardAdapter.swift */; };
-		585B10712577E294004F691E /* WireGuardAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B104B2577E293004F691E /* WireGuardAdapter.swift */; };
-		585B10732577E294004F691E /* Array+ConcurrentMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B104C2577E293004F691E /* Array+ConcurrentMap.swift */; };
-		585B10752577E294004F691E /* Array+ConcurrentMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B104C2577E293004F691E /* Array+ConcurrentMap.swift */; };
-		585B10772577E294004F691E /* DNSResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B104D2577E293004F691E /* DNSResolver.swift */; };
-		585B10792577E294004F691E /* DNSResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B104D2577E293004F691E /* DNSResolver.swift */; };
-		585B107B2577E294004F691E /* IPAddress+AddrInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B104E2577E293004F691E /* IPAddress+AddrInfo.swift */; };
-		585B107D2577E294004F691E /* IPAddress+AddrInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B104E2577E293004F691E /* IPAddress+AddrInfo.swift */; };
-		585B107E2577E294004F691E /* PrivateKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B104F2577E293004F691E /* PrivateKey.swift */; };
-		585B107F2577E294004F691E /* PrivateKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B104F2577E293004F691E /* PrivateKey.swift */; };
-		585B10802577E294004F691E /* PrivateKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B104F2577E293004F691E /* PrivateKey.swift */; };
-		585B10812577E294004F691E /* PrivateKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B104F2577E293004F691E /* PrivateKey.swift */; };
-		585B10832577E294004F691E /* PacketTunnelSettingsGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10502577E293004F691E /* PacketTunnelSettingsGenerator.swift */; };
-		585B10852577E294004F691E /* PacketTunnelSettingsGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10502577E293004F691E /* PacketTunnelSettingsGenerator.swift */; };
-		585B10862577E294004F691E /* IPAddressRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10512577E293004F691E /* IPAddressRange.swift */; };
-		585B10872577E294004F691E /* IPAddressRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10512577E293004F691E /* IPAddressRange.swift */; };
-		585B10882577E294004F691E /* IPAddressRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10512577E293004F691E /* IPAddressRange.swift */; };
-		585B10892577E294004F691E /* IPAddressRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10512577E293004F691E /* IPAddressRange.swift */; };
-		585B108A2577E294004F691E /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10522577E293004F691E /* Endpoint.swift */; };
-		585B108B2577E294004F691E /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10522577E293004F691E /* Endpoint.swift */; };
-		585B108C2577E294004F691E /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10522577E293004F691E /* Endpoint.swift */; };
-		585B108D2577E294004F691E /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585B10522577E293004F691E /* Endpoint.swift */; };
-		585B108E2577E294004F691E /* x25519.c in Sources */ = {isa = PBXBuildFile; fileRef = 585B10562577E293004F691E /* x25519.c */; };
-		585B108F2577E294004F691E /* x25519.c in Sources */ = {isa = PBXBuildFile; fileRef = 585B10562577E293004F691E /* x25519.c */; };
-		585B10902577E294004F691E /* x25519.c in Sources */ = {isa = PBXBuildFile; fileRef = 585B10562577E293004F691E /* x25519.c */; };
-		585B10912577E294004F691E /* x25519.c in Sources */ = {isa = PBXBuildFile; fileRef = 585B10562577E293004F691E /* x25519.c */; };
-		585B10922577E294004F691E /* key.c in Sources */ = {isa = PBXBuildFile; fileRef = 585B10572577E293004F691E /* key.c */; };
-		585B10932577E294004F691E /* key.c in Sources */ = {isa = PBXBuildFile; fileRef = 585B10572577E293004F691E /* key.c */; };
-		585B10942577E294004F691E /* key.c in Sources */ = {isa = PBXBuildFile; fileRef = 585B10572577E293004F691E /* key.c */; };
-		585B10952577E294004F691E /* key.c in Sources */ = {isa = PBXBuildFile; fileRef = 585B10572577E293004F691E /* key.c */; };
-		5892BFA025558288000E678D /* PacketTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5892BF9F25558288000E678D /* PacketTunnelProvider.swift */; };
-		5892BFA125558288000E678D /* PacketTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5892BF9F25558288000E678D /* PacketTunnelProvider.swift */; };
 		58BA78D52577F9C6006FAEA0 /* libwg-go.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58DB6CD52577F95D00FB6B73 /* libwg-go.a */; };
 		58DB6CD62577F95D00FB6B73 /* libwg-go.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58DB6CD52577F95D00FB6B73 /* libwg-go.a */; };
 		5CBE70062E4CF18B0050638D /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CBE70042E4CF16F0050638D /* libresolv.tbd */; };
 		5CBE70072E4CF18B0050638D /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CBE70042E4CF16F0050638D /* libresolv.tbd */; };
-		5CC6A71C2EE8F866008D120D /* HandshakeFreshnessEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC6A71B2EE8F866008D120D /* HandshakeFreshnessEvaluator.swift */; };
-		5CC6A71D2EE8F866008D120D /* HandshakeFreshnessEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC6A71B2EE8F866008D120D /* HandshakeFreshnessEvaluator.swift */; };
-		5CC6A71E2EE8F866008D120D /* HandshakeFreshnessEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC6A71B2EE8F866008D120D /* HandshakeFreshnessEvaluator.swift */; };
-		5CC6A71F2EE8F866008D120D /* HandshakeFreshnessEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC6A71B2EE8F866008D120D /* HandshakeFreshnessEvaluator.swift */; };
-		5F45417D21C1B23600994C13 /* UITableViewCell+Reuse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F45417C21C1B23600994C13 /* UITableViewCell+Reuse.swift */; };
-		5F45418C21C2D48200994C13 /* TunnelEditKeyValueCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F45418B21C2D48200994C13 /* TunnelEditKeyValueCell.swift */; };
-		5F45419021C2D53800994C13 /* SwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F45418F21C2D53800994C13 /* SwitchCell.swift */; };
-		5F45419221C2D55800994C13 /* CheckmarkCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F45419121C2D55800994C13 /* CheckmarkCell.swift */; };
-		5F45419821C2D60500994C13 /* KeyValueCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F45419721C2D60500994C13 /* KeyValueCell.swift */; };
-		5F4541A021C2D6B700994C13 /* TunnelListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F45419F21C2D6B700994C13 /* TunnelListCell.swift */; };
-		5F4541A221C2D6DF00994C13 /* BorderedTextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4541A121C2D6DF00994C13 /* BorderedTextButton.swift */; };
-		5F4541A621C4449E00994C13 /* ButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4541A521C4449E00994C13 /* ButtonCell.swift */; };
-		5F4541A921C451D100994C13 /* TunnelStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4541A821C451D100994C13 /* TunnelStatus.swift */; };
-		5F4541B221CBFAEE00994C13 /* String+ArrayConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4541B121CBFAEE00994C13 /* String+ArrayConversion.swift */; };
-		5F52D0BB21E3781B00283CEA /* ConfTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F52D0BA21E3781B00283CEA /* ConfTextView.swift */; };
-		5F52D0BD21E3785C00283CEA /* ConfTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F52D0BC21E3785C00283CEA /* ConfTextStorage.swift */; };
-		5F52D0BF21E3788900283CEA /* NSColor+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F52D0BE21E3788900283CEA /* NSColor+Hex.swift */; };
-		5F52D0C221E378C000283CEA /* highlighter.c in Sources */ = {isa = PBXBuildFile; fileRef = 5F52D0C121E378C000283CEA /* highlighter.c */; };
-		5F9696AE21CD6F72008063FE /* String+ArrayConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4541B121CBFAEE00994C13 /* String+ArrayConversion.swift */; };
-		5F9696B021CD7128008063FE /* TunnelConfiguration+WgQuickConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F9696AF21CD7128008063FE /* TunnelConfiguration+WgQuickConfig.swift */; };
-		5F9696B121CD7128008063FE /* TunnelConfiguration+WgQuickConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F9696AF21CD7128008063FE /* TunnelConfiguration+WgQuickConfig.swift */; };
-		6B5C5E27220A48D30024272E /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5C5E26220A48D30024272E /* Keychain.swift */; };
-		6B5C5E28220A48D30024272E /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5C5E26220A48D30024272E /* Keychain.swift */; };
-		6B5C5E29220A48D30024272E /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5C5E26220A48D30024272E /* Keychain.swift */; };
-		6B5C5E2A220A48D30024272E /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5C5E26220A48D30024272E /* Keychain.swift */; };
 		6B5CA6B1220DE4E900F126CF /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FF4AC462120B9E0002C96EB /* NetworkExtension.framework */; };
 		6B5CA6B2220DE4F400F126CF /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FB1BDB621D4F8B800A991BF /* NetworkExtension.framework */; };
-		6B62E45F220A6FA900EF34A6 /* PrivateDataConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B62E45E220A6FA900EF34A6 /* PrivateDataConfirmation.swift */; };
-		6B62E460220A6FA900EF34A6 /* PrivateDataConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B62E45E220A6FA900EF34A6 /* PrivateDataConfirmation.swift */; };
 		6B653B86220DE2960050E69C /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FF4AC462120B9E0002C96EB /* NetworkExtension.framework */; };
-		6B6956362211DA80001B618A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B6956352211DA80001B618A /* main.m */; };
-		6B707D8421F918D4000A8F73 /* TunnelConfiguration+UapiConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B707D8321F918D4000A8F73 /* TunnelConfiguration+UapiConfig.swift */; };
-		6B707D8621F918D4000A8F73 /* TunnelConfiguration+UapiConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B707D8321F918D4000A8F73 /* TunnelConfiguration+UapiConfig.swift */; };
-		6F0F44C9222D55BB00B0FF04 /* TextCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0F44C8222D55BB00B0FF04 /* TextCell.swift */; };
-		6F0F44CB222D55FD00B0FF04 /* EditableTextCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0F44CA222D55FD00B0FF04 /* EditableTextCell.swift */; };
-		6F1075642258AE9800D78929 /* DeleteTunnelsConfirmationAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1075632258AE9800D78929 /* DeleteTunnelsConfirmationAlert.swift */; };
-		6F19D30422402B8700A126F2 /* ConfirmationAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F19D30322402B8700A126F2 /* ConfirmationAlertPresenter.swift */; };
-		6F2449E8226587B90047B9E9 /* MacAppStoreUpdateDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F2449E7226587B80047B9E9 /* MacAppStoreUpdateDetector.swift */; };
-		6F29A9432278518D00DC6A6B /* RecentTunnelsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F29A9422278518D00DC6A6B /* RecentTunnelsTracker.swift */; };
-		6F29A94722787B1600DC6A6B /* QuickActionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F29A94622787B1600DC6A6B /* QuickActionItem.swift */; };
-		6F3E02E9228000F6001FE7E3 /* MainMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3E02E8228000F6001FE7E3 /* MainMenu.swift */; };
-		6F4DD16B21DA558800690EAE /* TunnelListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4DD16A21DA558800690EAE /* TunnelListRow.swift */; };
-		6F4DD16C21DA558F00690EAE /* NSTableView+Reuse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4DD16721DA552B00690EAE /* NSTableView+Reuse.swift */; };
-		6F4DD16E21DBEA0700690EAE /* ManageTunnelsRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4DD16D21DBEA0700690EAE /* ManageTunnelsRootViewController.swift */; };
-		6F5A2B4621AFDED40081EDD8 /* FileManager+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5A2B4421AFDE020081EDD8 /* FileManager+Extension.swift */; };
-		6F5A2B4821AFF49A0081EDD8 /* FileManager+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5A2B4421AFDE020081EDD8 /* FileManager+Extension.swift */; };
 		6F5D0C22218352EF000F85AD /* WireGuardNetworkExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 6F5D0C1A218352EF000F85AD /* WireGuardNetworkExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		6F5EA59B223E58A8002B380A /* ButtonRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5EA59A223E58A8002B380A /* ButtonRow.swift */; };
-		6F613D9B21DE33B8004B217A /* KeyValueRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F613D9A21DE33B8004B217A /* KeyValueRow.swift */; };
-		6F61F1E921B932F700483816 /* WireGuardAppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F61F1E821B932F700483816 /* WireGuardAppError.swift */; };
-		6F61F1EB21B937EF00483816 /* WireGuardResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F61F1EA21B937EF00483816 /* WireGuardResult.swift */; };
-		6F628C3D217F09E9003482A3 /* TunnelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F628C3C217F09E9003482A3 /* TunnelViewModel.swift */; };
-		6F628C41217F47DB003482A3 /* TunnelDetailTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F628C40217F47DB003482A3 /* TunnelDetailTableViewController.swift */; };
-		6F6483E7229293300075BA15 /* LaunchedAtLoginDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F6483E6229293300075BA15 /* LaunchedAtLoginDetector.swift */; };
 		6F70E23D22109E15008BDFB4 /* WireGuardLoginItemHelper.app in Embed Login Item Helper */ = {isa = PBXBuildFile; fileRef = 6F70E22922106A2D008BDFB4 /* WireGuardLoginItemHelper.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		6F7774E1217181B1006A79B3 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7774DF217181B1006A79B3 /* MainViewController.swift */; };
-		6F7774E2217181B1006A79B3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7774E0217181B1006A79B3 /* AppDelegate.swift */; };
-		6F7774E421718281006A79B3 /* TunnelsListTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7774E321718281006A79B3 /* TunnelsListTableViewController.swift */; };
-		6F7774EF21722D97006A79B3 /* TunnelsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7774EE21722D97006A79B3 /* TunnelsManager.swift */; };
-		6F7774F321774263006A79B3 /* TunnelEditTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7774F221774263006A79B3 /* TunnelEditTableViewController.swift */; };
-		6F7F7E5F21C7D74B00527607 /* TunnelErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7F7E5E21C7D74B00527607 /* TunnelErrors.swift */; };
-		6F89E17A21EDEB0E00C97BB9 /* StatusItemController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F89E17921EDEB0E00C97BB9 /* StatusItemController.swift */; };
-		6F89E17C21F090CC00C97BB9 /* TunnelsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F89E17B21F090CC00C97BB9 /* TunnelsTracker.swift */; };
-		6F8F0D7122258153000E8335 /* ActivateOnDemandViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F8F0D7022258153000E8335 /* ActivateOnDemandViewModel.swift */; };
-		6F8F0D7222258153000E8335 /* ActivateOnDemandViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F8F0D7022258153000E8335 /* ActivateOnDemandViewModel.swift */; };
-		6F8F0D7422267AD2000E8335 /* ChevronCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F8F0D7322267AD2000E8335 /* ChevronCell.swift */; };
-		6F8F0D7722267C57000E8335 /* SSIDOptionEditTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F8F0D7622267C57000E8335 /* SSIDOptionEditTableViewController.swift */; };
-		6F907C9C224663A2003CED21 /* LogViewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F907C9B224663A2003CED21 /* LogViewHelper.swift */; };
-		6F907C9D224663A2003CED21 /* LogViewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F907C9B224663A2003CED21 /* LogViewHelper.swift */; };
-		6F919EC3218A2AE90023B400 /* ErrorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F919EC2218A2AE90023B400 /* ErrorPresenter.swift */; };
-		6F919ED9218C65C50023B400 /* wireguard_doc_logo_22x29.png in Resources */ = {isa = PBXBuildFile; fileRef = 6F919ED5218C65C50023B400 /* wireguard_doc_logo_22x29.png */; };
-		6F919EDA218C65C50023B400 /* wireguard_doc_logo_44x58.png in Resources */ = {isa = PBXBuildFile; fileRef = 6F919ED6218C65C50023B400 /* wireguard_doc_logo_44x58.png */; };
-		6F919EDB218C65C50023B400 /* wireguard_doc_logo_64x64.png in Resources */ = {isa = PBXBuildFile; fileRef = 6F919ED7218C65C50023B400 /* wireguard_doc_logo_64x64.png */; };
-		6F919EDC218C65C50023B400 /* wireguard_doc_logo_320x320.png in Resources */ = {isa = PBXBuildFile; fileRef = 6F919ED8218C65C50023B400 /* wireguard_doc_logo_320x320.png */; };
-		6F9B8A8E223398610041B9C4 /* SSIDOptionDetailTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F9B8A8D223398610041B9C4 /* SSIDOptionDetailTableViewController.swift */; };
-		6FADE96C2254B8C300B838A4 /* UnusableTunnelDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FADE96A2254A6C200B838A4 /* UnusableTunnelDetailViewController.swift */; };
-		6FB1017921C57DE600766195 /* MockTunnels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB1017821C57DE600766195 /* MockTunnels.swift */; };
-		6FB17946222FD5960018AE71 /* OnDemandWiFiControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB17945222FD5960018AE71 /* OnDemandWiFiControls.swift */; };
-		6FB1BD6021D2607A00A991BF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB1BD5F21D2607A00A991BF /* AppDelegate.swift */; };
-		6FB1BD6221D2607E00A991BF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6FB1BD6121D2607E00A991BF /* Assets.xcassets */; };
 		6FB1BD9921D4BFE700A991BF /* WireGuardNetworkExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 6FB1BD9121D4BFE600A991BF /* WireGuardNetworkExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		6FB1BDA221D4F53300A991BF /* ringlogger.c in Sources */ = {isa = PBXBuildFile; fileRef = 6FF3526C21C23F960008484E /* ringlogger.c */; };
-		6FB1BDA421D4F53300A991BF /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF3526E21C23FA10008484E /* Logger.swift */; };
-		6FB1BDA521D4F53300A991BF /* TunnelConfiguration+WgQuickConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F9696AF21CD7128008063FE /* TunnelConfiguration+WgQuickConfig.swift */; };
-		6FB1BDA621D4F53300A991BF /* NETunnelProviderProtocol+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFA5D942194454A0001E2F7 /* NETunnelProviderProtocol+Extension.swift */; };
-		6FB1BDA721D4F53300A991BF /* String+ArrayConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4541B121CBFAEE00994C13 /* String+ArrayConversion.swift */; };
-		6FB1BDAF21D4F53300A991BF /* FileManager+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5A2B4421AFDE020081EDD8 /* FileManager+Extension.swift */; };
-		6FB1BDB321D4F55700A991BF /* ErrorNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFA5D9F21958ECC0001E2F7 /* ErrorNotifier.swift */; };
-		6FB1BDBC21D50F0200A991BF /* ringlogger.c in Sources */ = {isa = PBXBuildFile; fileRef = 6FF3526C21C23F960008484E /* ringlogger.c */; };
-		6FB1BDBD21D50F0200A991BF /* ringlogger.h in Sources */ = {isa = PBXBuildFile; fileRef = 6FF3526B21C23F960008484E /* ringlogger.h */; };
-		6FB1BDBE21D50F0200A991BF /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF3526E21C23FA10008484E /* Logger.swift */; };
-		6FB1BDBF21D50F0200A991BF /* TunnelConfiguration+WgQuickConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F9696AF21CD7128008063FE /* TunnelConfiguration+WgQuickConfig.swift */; };
-		6FB1BDC021D50F0200A991BF /* NETunnelProviderProtocol+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFA5D942194454A0001E2F7 /* NETunnelProviderProtocol+Extension.swift */; };
-		6FB1BDC121D50F0200A991BF /* String+ArrayConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4541B121CBFAEE00994C13 /* String+ArrayConversion.swift */; };
-		6FB1BDC921D50F0300A991BF /* FileManager+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5A2B4421AFDE020081EDD8 /* FileManager+Extension.swift */; };
-		6FB1BDCC21D50F5300A991BF /* TunnelsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7774EE21722D97006A79B3 /* TunnelsManager.swift */; };
-		6FB1BDCD21D50F5300A991BF /* ActivateOnDemandOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFA5DA32197085D0001E2F7 /* ActivateOnDemandOption.swift */; };
-		6FB1BDCE21D50F5300A991BF /* TunnelStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4541A821C451D100994C13 /* TunnelStatus.swift */; };
-		6FB1BDD021D50F5300A991BF /* TunnelErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F7F7E5E21C7D74B00527607 /* TunnelErrors.swift */; };
-		6FB1BDD121D50F5300A991BF /* ZipImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE254FA219C10800028284D /* ZipImporter.swift */; };
-		6FB1BDD221D50F5300A991BF /* ZipExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE254FE219C60290028284D /* ZipExporter.swift */; };
-		6FB1BDD321D50F5300A991BF /* ZipArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEF801218646B900D8FBF6 /* ZipArchive.swift */; };
-		6FB1BDD421D50F5300A991BF /* ioapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEF7FF21863C0100D8FBF6 /* ioapi.c */; };
-		6FB1BDD521D50F5300A991BF /* unzip.c in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEF7F621863B6100D8FBF6 /* unzip.c */; };
-		6FB1BDD621D50F5300A991BF /* zip.c in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEF7F721863B6100D8FBF6 /* zip.c */; };
-		6FB1BDD721D50F5300A991BF /* WireGuardAppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F61F1E821B932F700483816 /* WireGuardAppError.swift */; };
-		6FB1BDD821D50F5300A991BF /* WireGuardResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F61F1EA21B937EF00483816 /* WireGuardResult.swift */; };
-		6FB1BDD921D50F5300A991BF /* LocalizationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE1765921C90E87002690EA /* LocalizationHelper.swift */; };
 		6FB1BDDA21D5170800A991BF /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FB1BDB621D4F8B800A991BF /* NetworkExtension.framework */; };
-		6FBA101521D613F90051C35F /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBA101321D613F30051C35F /* Application.swift */; };
-		6FBA101821D656000051C35F /* StatusMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBA101621D655340051C35F /* StatusMenu.swift */; };
-		6FBA103B21D6B4290051C35F /* ErrorPresenterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBA103A21D6B4280051C35F /* ErrorPresenterProtocol.swift */; };
-		6FBA103E21D6B6D70051C35F /* TunnelImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBA103D21D6B6D70051C35F /* TunnelImporter.swift */; };
-		6FBA103F21D6B6FF0051C35F /* TunnelImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBA103D21D6B6D70051C35F /* TunnelImporter.swift */; };
-		6FBA104021D6B7040051C35F /* ErrorPresenterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBA103A21D6B4280051C35F /* ErrorPresenterProtocol.swift */; };
-		6FBA104321D6BC250051C35F /* ErrorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBA104121D6BC210051C35F /* ErrorPresenter.swift */; };
-		6FBA104621D7EBFA0051C35F /* TunnelsListTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBA104521D7EBFA0051C35F /* TunnelsListTableViewController.swift */; };
-		6FCD99AA21E0E14700BA4C82 /* ButtonedDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCD99A821E0E0C700BA4C82 /* ButtonedDetailViewController.swift */; };
-		6FCD99AF21E0EA1700BA4C82 /* ImportPanelPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCD99AE21E0EA1700BA4C82 /* ImportPanelPresenter.swift */; };
-		6FCD99B121E0EDA900BA4C82 /* TunnelEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FCD99B021E0EDA900BA4C82 /* TunnelEditViewController.swift */; };
-		6FDB3C3B21DCF47400A0C0BF /* TunnelDetailTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDB3C3A21DCF47400A0C0BF /* TunnelDetailTableViewController.swift */; };
-		6FDB3C3C21DCF6BB00A0C0BF /* TunnelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F628C3C217F09E9003482A3 /* TunnelViewModel.swift */; };
-		6FDB6D13224A15BF00EE4BC3 /* LogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDB6D12224A15BE00EE4BC3 /* LogViewController.swift */; };
-		6FDB6D15224CB2CE00EE4BC3 /* LogViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDB6D14224CB2CE00EE4BC3 /* LogViewCell.swift */; };
-		6FDB6D18224CC05A00EE4BC3 /* LogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDB6D16224CC04E00EE4BC3 /* LogViewController.swift */; };
-		6FDEF7E62185EFB200D8FBF6 /* QRScanViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEF7E52185EFAF00D8FBF6 /* QRScanViewController.swift */; };
-		6FDEF7FB21863B6100D8FBF6 /* unzip.c in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEF7F621863B6100D8FBF6 /* unzip.c */; };
-		6FDEF7FC21863B6100D8FBF6 /* zip.c in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEF7F721863B6100D8FBF6 /* zip.c */; };
-		6FDEF80021863C0100D8FBF6 /* ioapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEF7FF21863C0100D8FBF6 /* ioapi.c */; };
-		6FDEF802218646BA00D8FBF6 /* ZipArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEF801218646B900D8FBF6 /* ZipArchive.swift */; };
-		6FDEF806218725D200D8FBF6 /* SettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEF805218725D200D8FBF6 /* SettingsTableViewController.swift */; };
-		6FE1765A21C90E87002690EA /* LocalizationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE1765921C90E87002690EA /* LocalizationHelper.swift */; };
-		6FE254FB219C10800028284D /* ZipImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE254FA219C10800028284D /* ZipImporter.swift */; };
-		6FE254FF219C60290028284D /* ZipExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE254FE219C60290028284D /* ZipExporter.swift */; };
-		6FE3661D21F64F6B00F78C7D /* ConfTextColorTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FE3661C21F64F6B00F78C7D /* ConfTextColorTheme.swift */; };
-		6FF3527021C240160008484E /* ringlogger.c in Sources */ = {isa = PBXBuildFile; fileRef = 6FF3526C21C23F960008484E /* ringlogger.c */; };
-		6FF3527121C240160008484E /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF3526E21C23FA10008484E /* Logger.swift */; };
-		6FF3527221C2616C0008484E /* ringlogger.c in Sources */ = {isa = PBXBuildFile; fileRef = 6FF3526C21C23F960008484E /* ringlogger.c */; };
-		6FF3527321C2616C0008484E /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF3526E21C23FA10008484E /* Logger.swift */; };
-		6FF4AC1F211EC472002C96EB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6FF4AC1E211EC472002C96EB /* Assets.xcassets */; };
-		6FF4AC22211EC472002C96EB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6FF4AC20211EC472002C96EB /* LaunchScreen.storyboard */; };
-		6FFA5D952194454A0001E2F7 /* NETunnelProviderProtocol+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFA5D942194454A0001E2F7 /* NETunnelProviderProtocol+Extension.swift */; };
-		6FFA5D96219446380001E2F7 /* NETunnelProviderProtocol+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFA5D942194454A0001E2F7 /* NETunnelProviderProtocol+Extension.swift */; };
-		6FFA5DA021958ECC0001E2F7 /* ErrorNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFA5D9F21958ECC0001E2F7 /* ErrorNotifier.swift */; };
-		6FFA5DA42197085D0001E2F7 /* ActivateOnDemandOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFA5DA32197085D0001E2F7 /* ActivateOnDemandOption.swift */; };
-		6FFACD2021E4D8D500E9A2A5 /* ParseError+WireGuardAppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFACD1E21E4D89600E9A2A5 /* ParseError+WireGuardAppError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -289,150 +95,250 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		4E29B1C22BC1222C00824F53 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; name = InfoPlist.xcstrings; path = Sources/WireGuardApp/InfoPlist.xcstrings; sourceTree = "<group>"; };
-		4E5C5B932BA6367F00082DED /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Sources/WireGuardApp/PrivacyInfo.xcprivacy; sourceTree = SOURCE_ROOT; };
-		4E5C5B952BA636B300082DED /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		4E9BD26E2BC12AAB00D71616 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; name = Localizable.xcstrings; path = Sources/WireGuardApp/Localizable.xcstrings; sourceTree = "<group>"; };
-		4EC559AC2BC1250C00BBABBE /* mul */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; name = mul; path = mul.lproj/LaunchScreen.xcstrings; sourceTree = "<group>"; };
-		58233BCE2591F842002060A8 /* NotificationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationToken.swift; sourceTree = "<group>"; };
-		585B10462577E293004F691E /* InterfaceConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = InterfaceConfiguration.swift; sourceTree = "<group>"; tabWidth = 4; };
-		585B10472577E293004F691E /* PeerConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeerConfiguration.swift; sourceTree = "<group>"; };
-		585B10482577E293004F691E /* DNSServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DNSServer.swift; sourceTree = "<group>"; };
-		585B10492577E293004F691E /* TunnelConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TunnelConfiguration.swift; sourceTree = "<group>"; };
-		585B104B2577E293004F691E /* WireGuardAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WireGuardAdapter.swift; sourceTree = "<group>"; };
-		585B104C2577E293004F691E /* Array+ConcurrentMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+ConcurrentMap.swift"; sourceTree = "<group>"; };
-		585B104D2577E293004F691E /* DNSResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DNSResolver.swift; sourceTree = "<group>"; };
-		585B104E2577E293004F691E /* IPAddress+AddrInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IPAddress+AddrInfo.swift"; sourceTree = "<group>"; };
-		585B104F2577E293004F691E /* PrivateKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateKey.swift; sourceTree = "<group>"; };
-		585B10502577E293004F691E /* PacketTunnelSettingsGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = PacketTunnelSettingsGenerator.swift; sourceTree = "<group>"; tabWidth = 4; };
-		585B10512577E293004F691E /* IPAddressRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IPAddressRange.swift; sourceTree = "<group>"; };
-		585B10522577E293004F691E /* Endpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
-		585B10542577E293004F691E /* WireGuardKitC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WireGuardKitC.h; sourceTree = "<group>"; };
-		585B10552577E293004F691E /* key.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = key.h; sourceTree = "<group>"; };
-		585B10562577E293004F691E /* x25519.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = x25519.c; sourceTree = "<group>"; };
-		585B10572577E293004F691E /* key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = key.c; sourceTree = "<group>"; };
-		585B10592577E293004F691E /* x25519.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = x25519.h; sourceTree = "<group>"; };
-		5892BF9F25558288000E678D /* PacketTunnelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelProvider.swift; sourceTree = "<group>"; };
 		58DB6CD52577F95D00FB6B73 /* libwg-go.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libwg-go.a"; path = "../../../../../../../../Development/git/amneziawg-apple/Sources/WireGuardKitGo/out/libwg-go.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CBE70042E4CF16F0050638D /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = usr/lib/libresolv.tbd; sourceTree = SDKROOT; };
-		5CC6A71B2EE8F866008D120D /* HandshakeFreshnessEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandshakeFreshnessEvaluator.swift; sourceTree = "<group>"; };
-		5F45417C21C1B23600994C13 /* UITableViewCell+Reuse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Reuse.swift"; sourceTree = "<group>"; };
-		5F45418B21C2D48200994C13 /* TunnelEditKeyValueCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelEditKeyValueCell.swift; sourceTree = "<group>"; };
-		5F45418F21C2D53800994C13 /* SwitchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchCell.swift; sourceTree = "<group>"; };
-		5F45419121C2D55800994C13 /* CheckmarkCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckmarkCell.swift; sourceTree = "<group>"; };
-		5F45419721C2D60500994C13 /* KeyValueCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValueCell.swift; sourceTree = "<group>"; };
-		5F45419F21C2D6B700994C13 /* TunnelListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelListCell.swift; sourceTree = "<group>"; };
-		5F4541A121C2D6DF00994C13 /* BorderedTextButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BorderedTextButton.swift; sourceTree = "<group>"; };
-		5F4541A521C4449E00994C13 /* ButtonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonCell.swift; sourceTree = "<group>"; };
-		5F4541A821C451D100994C13 /* TunnelStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelStatus.swift; sourceTree = "<group>"; };
-		5F4541B121CBFAEE00994C13 /* String+ArrayConversion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+ArrayConversion.swift"; sourceTree = "<group>"; };
-		5F52D0BA21E3781B00283CEA /* ConfTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfTextView.swift; sourceTree = "<group>"; };
-		5F52D0BC21E3785C00283CEA /* ConfTextStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfTextStorage.swift; sourceTree = "<group>"; };
-		5F52D0BE21E3788900283CEA /* NSColor+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSColor+Hex.swift"; sourceTree = "<group>"; };
-		5F52D0C021E378C000283CEA /* highlighter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = highlighter.h; sourceTree = "<group>"; };
-		5F52D0C121E378C000283CEA /* highlighter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = highlighter.c; sourceTree = "<group>"; };
-		5F9696AF21CD7128008063FE /* TunnelConfiguration+WgQuickConfig.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = "TunnelConfiguration+WgQuickConfig.swift"; sourceTree = "<group>"; tabWidth = 4; };
-		6B5C5E26220A48D30024272E /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
-		6B62E45E220A6FA900EF34A6 /* PrivateDataConfirmation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateDataConfirmation.swift; sourceTree = "<group>"; };
-		6B6956352211DA80001B618A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		6B707D8321F918D4000A8F73 /* TunnelConfiguration+UapiConfig.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = "TunnelConfiguration+UapiConfig.swift"; sourceTree = "<group>"; tabWidth = 4; };
-		6F0F44C8222D55BB00B0FF04 /* TextCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCell.swift; sourceTree = "<group>"; };
-		6F0F44CA222D55FD00B0FF04 /* EditableTextCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableTextCell.swift; sourceTree = "<group>"; };
-		6F1075632258AE9800D78929 /* DeleteTunnelsConfirmationAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteTunnelsConfirmationAlert.swift; sourceTree = "<group>"; };
-		6F19D30322402B8700A126F2 /* ConfirmationAlertPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmationAlertPresenter.swift; sourceTree = "<group>"; };
-		6F2449E7226587B80047B9E9 /* MacAppStoreUpdateDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacAppStoreUpdateDetector.swift; sourceTree = "<group>"; };
-		6F29A9422278518D00DC6A6B /* RecentTunnelsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentTunnelsTracker.swift; sourceTree = "<group>"; };
-		6F29A94622787B1600DC6A6B /* QuickActionItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuickActionItem.swift; sourceTree = "<group>"; };
-		6F3E02E8228000F6001FE7E3 /* MainMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainMenu.swift; sourceTree = "<group>"; };
-		6F4DD16721DA552B00690EAE /* NSTableView+Reuse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTableView+Reuse.swift"; sourceTree = "<group>"; };
-		6F4DD16A21DA558800690EAE /* TunnelListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelListRow.swift; sourceTree = "<group>"; };
-		6F4DD16D21DBEA0700690EAE /* ManageTunnelsRootViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageTunnelsRootViewController.swift; sourceTree = "<group>"; };
-		6F5A2B4421AFDE020081EDD8 /* FileManager+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Extension.swift"; sourceTree = "<group>"; };
 		6F5D0C1A218352EF000F85AD /* WireGuardNetworkExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WireGuardNetworkExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		6F5D0C1E218352EF000F85AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		6F5D0C1F218352EF000F85AD /* WireGuardNetworkExtension_iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WireGuardNetworkExtension_iOS.entitlements; sourceTree = "<group>"; };
-		6F5D0C3421839E37000F85AD /* WireGuardNetworkExtension-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WireGuardNetworkExtension-Bridging-Header.h"; sourceTree = "<group>"; };
-		6F5EA59A223E58A8002B380A /* ButtonRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonRow.swift; sourceTree = "<group>"; };
-		6F613D9A21DE33B8004B217A /* KeyValueRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValueRow.swift; sourceTree = "<group>"; };
-		6F61F1E821B932F700483816 /* WireGuardAppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireGuardAppError.swift; sourceTree = "<group>"; };
-		6F61F1EA21B937EF00483816 /* WireGuardResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WireGuardResult.swift; sourceTree = "<group>"; };
-		6F628C3C217F09E9003482A3 /* TunnelViewModel.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = TunnelViewModel.swift; sourceTree = "<group>"; tabWidth = 4; };
-		6F628C40217F47DB003482A3 /* TunnelDetailTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = TunnelDetailTableViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
-		6F6483E6229293300075BA15 /* LaunchedAtLoginDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchedAtLoginDetector.swift; sourceTree = "<group>"; };
-		6F689999218043390012E523 /* WireGuard-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WireGuard-Bridging-Header.h"; sourceTree = "<group>"; };
 		6F70E22922106A2D008BDFB4 /* WireGuardLoginItemHelper.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WireGuardLoginItemHelper.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		6F70E23222106A31008BDFB4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		6F70E23922109BEF008BDFB4 /* LoginItemHelper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LoginItemHelper.entitlements; sourceTree = "<group>"; };
-		6F7774DF217181B1006A79B3 /* MainViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
-		6F7774E0217181B1006A79B3 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		6F7774E321718281006A79B3 /* TunnelsListTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TunnelsListTableViewController.swift; sourceTree = "<group>"; };
-		6F7774EE21722D97006A79B3 /* TunnelsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelsManager.swift; sourceTree = "<group>"; };
-		6F7774F221774263006A79B3 /* TunnelEditTableViewController.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = TunnelEditTableViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
-		6F7F7E5E21C7D74B00527607 /* TunnelErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelErrors.swift; sourceTree = "<group>"; };
-		6F89E17921EDEB0E00C97BB9 /* StatusItemController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusItemController.swift; sourceTree = "<group>"; };
-		6F89E17B21F090CC00C97BB9 /* TunnelsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelsTracker.swift; sourceTree = "<group>"; };
-		6F8F0D7022258153000E8335 /* ActivateOnDemandViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivateOnDemandViewModel.swift; sourceTree = "<group>"; };
-		6F8F0D7322267AD2000E8335 /* ChevronCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChevronCell.swift; sourceTree = "<group>"; };
-		6F8F0D7622267C57000E8335 /* SSIDOptionEditTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSIDOptionEditTableViewController.swift; sourceTree = "<group>"; };
-		6F907C9B224663A2003CED21 /* LogViewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewHelper.swift; sourceTree = "<group>"; };
-		6F919EC2218A2AE90023B400 /* ErrorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorPresenter.swift; sourceTree = "<group>"; };
-		6F919ED5218C65C50023B400 /* wireguard_doc_logo_22x29.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = wireguard_doc_logo_22x29.png; sourceTree = "<group>"; };
-		6F919ED6218C65C50023B400 /* wireguard_doc_logo_44x58.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = wireguard_doc_logo_44x58.png; sourceTree = "<group>"; };
-		6F919ED7218C65C50023B400 /* wireguard_doc_logo_64x64.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = wireguard_doc_logo_64x64.png; sourceTree = "<group>"; };
-		6F919ED8218C65C50023B400 /* wireguard_doc_logo_320x320.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = wireguard_doc_logo_320x320.png; sourceTree = "<group>"; };
-		6F9B8A8D223398610041B9C4 /* SSIDOptionDetailTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSIDOptionDetailTableViewController.swift; sourceTree = "<group>"; };
-		6FADE96A2254A6C200B838A4 /* UnusableTunnelDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnusableTunnelDetailViewController.swift; sourceTree = "<group>"; };
-		6FB1017821C57DE600766195 /* MockTunnels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTunnels.swift; sourceTree = "<group>"; };
-		6FB17945222FD5960018AE71 /* OnDemandWiFiControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnDemandWiFiControls.swift; sourceTree = "<group>"; };
 		6FB1BD5D21D2607A00A991BF /* AmneziaWG.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AmneziaWG.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		6FB1BD5F21D2607A00A991BF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		6FB1BD6121D2607E00A991BF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		6FB1BD6621D2607E00A991BF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		6FB1BD6721D2607E00A991BF /* WireGuard.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WireGuard.entitlements; sourceTree = "<group>"; };
 		6FB1BD9121D4BFE600A991BF /* WireGuardNetworkExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WireGuardNetworkExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		6FB1BD9621D4BFE700A991BF /* WireGuardNetworkExtension_macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WireGuardNetworkExtension_macOS.entitlements; sourceTree = "<group>"; };
 		6FB1BDB621D4F8B800A991BF /* NetworkExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NetworkExtension.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/NetworkExtension.framework; sourceTree = DEVELOPER_DIR; };
-		6FBA101321D613F30051C35F /* Application.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Application.swift; sourceTree = "<group>"; };
-		6FBA101621D655340051C35F /* StatusMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusMenu.swift; sourceTree = "<group>"; };
-		6FBA103A21D6B4280051C35F /* ErrorPresenterProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorPresenterProtocol.swift; sourceTree = "<group>"; };
-		6FBA103D21D6B6D70051C35F /* TunnelImporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TunnelImporter.swift; sourceTree = "<group>"; };
-		6FBA104121D6BC210051C35F /* ErrorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorPresenter.swift; sourceTree = "<group>"; };
-		6FBA104521D7EBFA0051C35F /* TunnelsListTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelsListTableViewController.swift; sourceTree = "<group>"; };
-		6FCD99A821E0E0C700BA4C82 /* ButtonedDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonedDetailViewController.swift; sourceTree = "<group>"; };
-		6FCD99AE21E0EA1700BA4C82 /* ImportPanelPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportPanelPresenter.swift; sourceTree = "<group>"; };
-		6FCD99B021E0EDA900BA4C82 /* TunnelEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelEditViewController.swift; sourceTree = "<group>"; };
-		6FDB3C3A21DCF47400A0C0BF /* TunnelDetailTableViewController.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = TunnelDetailTableViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
-		6FDB6D12224A15BE00EE4BC3 /* LogViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogViewController.swift; sourceTree = "<group>"; };
-		6FDB6D14224CB2CE00EE4BC3 /* LogViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewCell.swift; sourceTree = "<group>"; };
-		6FDB6D16224CC04E00EE4BC3 /* LogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewController.swift; sourceTree = "<group>"; };
-		6FDEF7E52185EFAF00D8FBF6 /* QRScanViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QRScanViewController.swift; sourceTree = "<group>"; };
-		6FDEF7F621863B6100D8FBF6 /* unzip.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = unzip.c; sourceTree = "<group>"; };
-		6FDEF7F721863B6100D8FBF6 /* zip.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = zip.c; sourceTree = "<group>"; };
-		6FDEF7F921863B6100D8FBF6 /* zip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = zip.h; sourceTree = "<group>"; };
-		6FDEF7FA21863B6100D8FBF6 /* unzip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unzip.h; sourceTree = "<group>"; };
-		6FDEF7FE21863C0100D8FBF6 /* ioapi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ioapi.h; sourceTree = "<group>"; };
-		6FDEF7FF21863C0100D8FBF6 /* ioapi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ioapi.c; sourceTree = "<group>"; };
-		6FDEF801218646B900D8FBF6 /* ZipArchive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZipArchive.swift; sourceTree = "<group>"; };
-		6FDEF805218725D200D8FBF6 /* SettingsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = SettingsTableViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
-		6FE1765921C90E87002690EA /* LocalizationHelper.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = LocalizationHelper.swift; sourceTree = "<group>"; tabWidth = 4; };
-		6FE254FA219C10800028284D /* ZipImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipImporter.swift; sourceTree = "<group>"; };
-		6FE254FE219C60290028284D /* ZipExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZipExporter.swift; sourceTree = "<group>"; };
-		6FE3661C21F64F6B00F78C7D /* ConfTextColorTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfTextColorTheme.swift; sourceTree = "<group>"; };
-		6FF3526B21C23F960008484E /* ringlogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ringlogger.h; sourceTree = "<group>"; };
-		6FF3526C21C23F960008484E /* ringlogger.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ringlogger.c; sourceTree = "<group>"; };
-		6FF3526E21C23FA10008484E /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		6FF4AC14211EC46F002C96EB /* AmneziaWG.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AmneziaWG.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		6FF4AC1E211EC472002C96EB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		6FF4AC21211EC472002C96EB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		6FF4AC23211EC472002C96EB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		6FF4AC2B211EC776002C96EB /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Config.xcconfig; path = Config/Config.xcconfig; sourceTree = "<group>"; };
 		6FF4AC462120B9E0002C96EB /* NetworkExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NetworkExtension.framework; path = System/Library/Frameworks/NetworkExtension.framework; sourceTree = SDKROOT; };
-		6FF4AC482120B9E0002C96EB /* WireGuard.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WireGuard.entitlements; sourceTree = "<group>"; };
-		6FFA5D942194454A0001E2F7 /* NETunnelProviderProtocol+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NETunnelProviderProtocol+Extension.swift"; sourceTree = "<group>"; };
-		6FFA5D9F21958ECC0001E2F7 /* ErrorNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorNotifier.swift; sourceTree = "<group>"; };
-		6FFA5DA32197085D0001E2F7 /* ActivateOnDemandOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivateOnDemandOption.swift; sourceTree = "<group>"; };
-		6FFACD1E21E4D89600E9A2A5 /* ParseError+WireGuardAppError.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = "ParseError+WireGuardAppError.swift"; sourceTree = "<group>"; tabWidth = 4; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		0A1D204F301905B400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Logging/test_ringlogger.c,
+			);
+			target = 6FF4AC13211EC46F002C96EB /* WireGuardiOS */;
+		};
+		0A1D2050301905B400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Logging/test_ringlogger.c,
+				NotificationToken.swift,
+			);
+			target = 6F5D0C19218352EF000F85AD /* WireGuardNetworkExtensioniOS */;
+		};
+		0A1D2051301905B400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Logging/test_ringlogger.c,
+			);
+			target = 6FB1BD5C21D2607A00A991BF /* WireGuardmacOS */;
+		};
+		0A1D2053301905B400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Logging/test_ringlogger.c,
+				NotificationToken.swift,
+			);
+			target = 6FB1BD9021D4BFE600A991BF /* WireGuardNetworkExtensionmacOS */;
+		};
+		0A1D20A63019061400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"Array+ConcurrentMap.swift",
+				DNSResolver.swift,
+				"IPAddress+AddrInfo.swift",
+				PacketTunnelSettingsGenerator.swift,
+				WireGuardAdapter.swift,
+			);
+			target = 6FF4AC13211EC46F002C96EB /* WireGuardiOS */;
+		};
+		0A1D20A73019061400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"Array+ConcurrentMap.swift",
+				DNSResolver.swift,
+				"IPAddress+AddrInfo.swift",
+				PacketTunnelSettingsGenerator.swift,
+				WireGuardAdapter.swift,
+			);
+			target = 6FB1BD5C21D2607A00A991BF /* WireGuardmacOS */;
+		};
+		0A1D20A83019061400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				key.c,
+				x25519.c,
+			);
+			target = 6FF4AC13211EC46F002C96EB /* WireGuardiOS */;
+		};
+		0A1D20A93019061400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				key.c,
+				x25519.c,
+			);
+			target = 6F5D0C19218352EF000F85AD /* WireGuardNetworkExtensioniOS */;
+		};
+		0A1D20AA3019061400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				key.c,
+				x25519.c,
+			);
+			target = 6FB1BD5C21D2607A00A991BF /* WireGuardmacOS */;
+		};
+		0A1D20AB3019061400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				key.c,
+				x25519.c,
+			);
+			target = 6FB1BD9021D4BFE600A991BF /* WireGuardNetworkExtensionmacOS */;
+		};
+		0A1D20B93019062100A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				ErrorNotifier.swift,
+				PacketTunnelProvider.swift,
+				PrivacyInfo.xcprivacy,
+			);
+			target = 6F5D0C19218352EF000F85AD /* WireGuardNetworkExtensioniOS */;
+		};
+		0A1D20BA3019062100A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				ErrorNotifier.swift,
+				PacketTunnelProvider.swift,
+			);
+			target = 6FB1BD9021D4BFE600A991BF /* WireGuardNetworkExtensionmacOS */;
+		};
+		0A1D238C3019071C00A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Config/Config.xcconfig,
+				Config/Developer.xcconfig,
+				Config/Developer.xcconfig.template,
+				Config/Version.xcconfig,
+				UI/iOS/Info.plist,
+				UI/macOS/AppDelegate.swift,
+				UI/macOS/Application.swift,
+				UI/macOS/Assets.xcassets,
+				UI/macOS/ErrorPresenter.swift,
+				UI/macOS/ImportPanelPresenter.swift,
+				UI/macOS/Info.plist,
+				UI/macOS/LaunchedAtLoginDetector.swift,
+				UI/macOS/LoginItemHelper/Info.plist,
+				UI/macOS/LoginItemHelper/main.m,
+				UI/macOS/MacAppStoreUpdateDetector.swift,
+				UI/macOS/MainMenu.swift,
+				"UI/macOS/NSColor+Hex.swift",
+				"UI/macOS/NSTableView+Reuse.swift",
+				"UI/macOS/ParseError+WireGuardAppError.swift",
+				UI/macOS/StatusItemController.swift,
+				UI/macOS/StatusMenu.swift,
+				UI/macOS/TunnelsTracker.swift,
+				UI/macOS/View/ButtonRow.swift,
+				UI/macOS/View/ConfTextColorTheme.swift,
+				UI/macOS/View/ConfTextStorage.swift,
+				UI/macOS/View/ConfTextView.swift,
+				UI/macOS/View/DeleteTunnelsConfirmationAlert.swift,
+				UI/macOS/View/highlighter.c,
+				UI/macOS/View/KeyValueRow.swift,
+				UI/macOS/View/LogViewCell.swift,
+				UI/macOS/View/OnDemandWiFiControls.swift,
+				UI/macOS/View/TunnelListRow.swift,
+				UI/macOS/ViewController/ButtonedDetailViewController.swift,
+				UI/macOS/ViewController/LogViewController.swift,
+				UI/macOS/ViewController/ManageTunnelsRootViewController.swift,
+				UI/macOS/ViewController/TunnelDetailTableViewController.swift,
+				UI/macOS/ViewController/TunnelEditViewController.swift,
+				UI/macOS/ViewController/TunnelsListTableViewController.swift,
+				UI/macOS/ViewController/UnusableTunnelDetailViewController.swift,
+			);
+			target = 6FF4AC13211EC46F002C96EB /* WireGuardiOS */;
+		};
+		0A1D238D3019071C00A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Localizable.xcstrings,
+				LocalizationHelper.swift,
+				Tunnel/ActivateOnDemandOption.swift,
+				Tunnel/MockTunnels.swift,
+				"Tunnel/TunnelConfiguration+UapiConfig.swift",
+				Tunnel/TunnelErrors.swift,
+				Tunnel/TunnelsManager.swift,
+				Tunnel/TunnelStatus.swift,
+				UI/ActivateOnDemandViewModel.swift,
+				UI/ErrorPresenterProtocol.swift,
+				UI/LogViewHelper.swift,
+				UI/macOS/AppDelegate.swift,
+				UI/macOS/Application.swift,
+				UI/macOS/Assets.xcassets,
+				UI/macOS/ErrorPresenter.swift,
+				UI/macOS/ImportPanelPresenter.swift,
+				UI/macOS/LaunchedAtLoginDetector.swift,
+				UI/macOS/MacAppStoreUpdateDetector.swift,
+				UI/macOS/MainMenu.swift,
+				"UI/macOS/NSColor+Hex.swift",
+				"UI/macOS/NSTableView+Reuse.swift",
+				"UI/macOS/ParseError+WireGuardAppError.swift",
+				UI/macOS/StatusItemController.swift,
+				UI/macOS/StatusMenu.swift,
+				UI/macOS/TunnelsTracker.swift,
+				UI/macOS/View/ButtonRow.swift,
+				UI/macOS/View/ConfTextColorTheme.swift,
+				UI/macOS/View/ConfTextStorage.swift,
+				UI/macOS/View/ConfTextView.swift,
+				UI/macOS/View/DeleteTunnelsConfirmationAlert.swift,
+				UI/macOS/View/highlighter.c,
+				UI/macOS/View/KeyValueRow.swift,
+				UI/macOS/View/LogViewCell.swift,
+				UI/macOS/View/OnDemandWiFiControls.swift,
+				UI/macOS/View/TunnelListRow.swift,
+				UI/macOS/ViewController/ButtonedDetailViewController.swift,
+				UI/macOS/ViewController/LogViewController.swift,
+				UI/macOS/ViewController/ManageTunnelsRootViewController.swift,
+				UI/macOS/ViewController/TunnelDetailTableViewController.swift,
+				UI/macOS/ViewController/TunnelEditViewController.swift,
+				UI/macOS/ViewController/TunnelsListTableViewController.swift,
+				UI/macOS/ViewController/UnusableTunnelDetailViewController.swift,
+				UI/PrivateDataConfirmation.swift,
+				UI/TunnelImporter.swift,
+				UI/TunnelViewModel.swift,
+				WireGuardAppError.swift,
+				WireGuardResult.swift,
+				ZipArchive/3rdparty/minizip/ioapi.c,
+				ZipArchive/3rdparty/minizip/MiniZip64_info.txt,
+				ZipArchive/3rdparty/minizip/unzip.c,
+				ZipArchive/3rdparty/minizip/zip.c,
+				ZipArchive/ZipArchive.swift,
+				ZipArchive/ZipExporter.swift,
+				ZipArchive/ZipImporter.swift,
+			);
+			target = 6FB1BD5C21D2607A00A991BF /* WireGuardmacOS */;
+		};
+		0A1D238E3019071C00A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				UI/macOS/LoginItemHelper/main.m,
+			);
+			target = 6F70E22822106A2D008BDFB4 /* WireGuardmacOSLoginItemHelper */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
+		0A1D2052301905B400A51D75 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet;
+			buildPhase = 6FB1BD5921D2607A00A991BF /* Sources */;
+			membershipExceptions = (
+				Logging/ringlogger.h,
+			);
+		};
+/* End PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		0A1D2029301905B300A51D75 /* Shared */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (0A1D204F301905B400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 0A1D2050301905B400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 0A1D2051301905B400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 0A1D2052301905B400A51D75 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */, 0A1D2053301905B400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); name = Shared; path = Sources/Shared; sourceTree = "<group>"; };
+		0A1D205B3019061300A51D75 /* WireGuardKitC */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (0A1D20A83019061400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 0A1D20A93019061400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 0A1D20AA3019061400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 0A1D20AB3019061400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); name = WireGuardKitC; path = Sources/WireGuardKitC; sourceTree = "<group>"; };
+		0A1D20713019061300A51D75 /* WireGuardKit */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (0A1D20A63019061400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 0A1D20A73019061400A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); name = WireGuardKit; path = Sources/WireGuardKit; sourceTree = "<group>"; };
+		0A1D20B33019062000A51D75 /* WireGuardNetworkExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (0A1D20B93019062100A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 0A1D20BA3019062100A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); name = WireGuardNetworkExtension; path = Sources/WireGuardNetworkExtension; sourceTree = "<group>"; };
+		0A1D22F53019071B00A51D75 /* WireGuardApp */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (0A1D238C3019071C00A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 0A1D238D3019071C00A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 0A1D238E3019071C00A51D75 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); name = WireGuardApp; path = Sources/WireGuardApp; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		6F5D0C17218352EF000F85AD /* Frameworks */ = {
@@ -474,298 +380,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		585B10452577E293004F691E /* WireGuardKit */ = {
-			isa = PBXGroup;
-			children = (
-				5CC6A71B2EE8F866008D120D /* HandshakeFreshnessEvaluator.swift */,
-				585B104C2577E293004F691E /* Array+ConcurrentMap.swift */,
-				585B104D2577E293004F691E /* DNSResolver.swift */,
-				585B10482577E293004F691E /* DNSServer.swift */,
-				585B10522577E293004F691E /* Endpoint.swift */,
-				585B10462577E293004F691E /* InterfaceConfiguration.swift */,
-				585B104E2577E293004F691E /* IPAddress+AddrInfo.swift */,
-				585B10512577E293004F691E /* IPAddressRange.swift */,
-				585B10502577E293004F691E /* PacketTunnelSettingsGenerator.swift */,
-				585B10472577E293004F691E /* PeerConfiguration.swift */,
-				585B104F2577E293004F691E /* PrivateKey.swift */,
-				585B10492577E293004F691E /* TunnelConfiguration.swift */,
-				585B104B2577E293004F691E /* WireGuardAdapter.swift */,
-			);
-			name = WireGuardKit;
-			path = Sources/WireGuardKit;
-			sourceTree = "<group>";
-		};
-		585B10532577E293004F691E /* WireGuardKitC */ = {
-			isa = PBXGroup;
-			children = (
-				585B10572577E293004F691E /* key.c */,
-				585B10552577E293004F691E /* key.h */,
-				585B10542577E293004F691E /* WireGuardKitC.h */,
-				585B10562577E293004F691E /* x25519.c */,
-				585B10592577E293004F691E /* x25519.h */,
-			);
-			name = WireGuardKitC;
-			path = Sources/WireGuardKitC;
-			sourceTree = "<group>";
-		};
-		5F4541A721C44F5B00994C13 /* View */ = {
-			isa = PBXGroup;
-			children = (
-				5F45419F21C2D6B700994C13 /* TunnelListCell.swift */,
-				5F45418B21C2D48200994C13 /* TunnelEditKeyValueCell.swift */,
-				5F45418F21C2D53800994C13 /* SwitchCell.swift */,
-				5F45419721C2D60500994C13 /* KeyValueCell.swift */,
-				5F4541A521C4449E00994C13 /* ButtonCell.swift */,
-				5F45419121C2D55800994C13 /* CheckmarkCell.swift */,
-				5F4541A121C2D6DF00994C13 /* BorderedTextButton.swift */,
-				6F8F0D7322267AD2000E8335 /* ChevronCell.swift */,
-				6F0F44C8222D55BB00B0FF04 /* TextCell.swift */,
-				6F0F44CA222D55FD00B0FF04 /* EditableTextCell.swift */,
-			);
-			path = View;
-			sourceTree = "<group>";
-		};
-		5F4541AC21C4720B00994C13 /* ViewController */ = {
-			isa = PBXGroup;
-			children = (
-				6F7774E321718281006A79B3 /* TunnelsListTableViewController.swift */,
-				6F7774F221774263006A79B3 /* TunnelEditTableViewController.swift */,
-				6FDEF7E52185EFAF00D8FBF6 /* QRScanViewController.swift */,
-				6F628C40217F47DB003482A3 /* TunnelDetailTableViewController.swift */,
-				6FDEF805218725D200D8FBF6 /* SettingsTableViewController.swift */,
-				6F7774DF217181B1006A79B3 /* MainViewController.swift */,
-				6F8F0D7622267C57000E8335 /* SSIDOptionEditTableViewController.swift */,
-				6F9B8A8D223398610041B9C4 /* SSIDOptionDetailTableViewController.swift */,
-				6FDB6D16224CC04E00EE4BC3 /* LogViewController.swift */,
-			);
-			path = ViewController;
-			sourceTree = "<group>";
-		};
-		6F4DD16921DA556600690EAE /* View */ = {
-			isa = PBXGroup;
-			children = (
-				5F52D0C021E378C000283CEA /* highlighter.h */,
-				5F52D0C121E378C000283CEA /* highlighter.c */,
-				6F4DD16A21DA558800690EAE /* TunnelListRow.swift */,
-				6F613D9A21DE33B8004B217A /* KeyValueRow.swift */,
-				5F52D0BA21E3781B00283CEA /* ConfTextView.swift */,
-				5F52D0BC21E3785C00283CEA /* ConfTextStorage.swift */,
-				6FE3661C21F64F6B00F78C7D /* ConfTextColorTheme.swift */,
-				6F5EA59A223E58A8002B380A /* ButtonRow.swift */,
-				6FB17945222FD5960018AE71 /* OnDemandWiFiControls.swift */,
-				6FDB6D14224CB2CE00EE4BC3 /* LogViewCell.swift */,
-				6F1075632258AE9800D78929 /* DeleteTunnelsConfirmationAlert.swift */,
-			);
-			path = View;
-			sourceTree = "<group>";
-		};
-		6F5D0C1B218352EF000F85AD /* WireGuardNetworkExtension */ = {
-			isa = PBXGroup;
-			children = (
-				6F5D0C1E218352EF000F85AD /* Info.plist */,
-				6F5D0C1F218352EF000F85AD /* WireGuardNetworkExtension_iOS.entitlements */,
-				6FB1BD9621D4BFE700A991BF /* WireGuardNetworkExtension_macOS.entitlements */,
-				6F5D0C3421839E37000F85AD /* WireGuardNetworkExtension-Bridging-Header.h */,
-				6FFA5D9F21958ECC0001E2F7 /* ErrorNotifier.swift */,
-				5892BF9F25558288000E678D /* PacketTunnelProvider.swift */,
-				4E5C5B952BA636B300082DED /* PrivacyInfo.xcprivacy */,
-			);
-			name = WireGuardNetworkExtension;
-			path = Sources/WireGuardNetworkExtension;
-			sourceTree = "<group>";
-		};
-		6F5D0C432183B4A4000F85AD /* Shared */ = {
-			isa = PBXGroup;
-			children = (
-				6FF3526A21C23F720008484E /* Logging */,
-				6F7774E6217201E0006A79B3 /* Model */,
-				6F5A2B4421AFDE020081EDD8 /* FileManager+Extension.swift */,
-				6B5C5E26220A48D30024272E /* Keychain.swift */,
-				58233BCE2591F842002060A8 /* NotificationToken.swift */,
-			);
-			name = Shared;
-			path = Sources/Shared;
-			sourceTree = "<group>";
-		};
-		6F70E22A22106A2D008BDFB4 /* LoginItemHelper */ = {
-			isa = PBXGroup;
-			children = (
-				6F70E23922109BEF008BDFB4 /* LoginItemHelper.entitlements */,
-				6F70E23222106A31008BDFB4 /* Info.plist */,
-				6B6956352211DA80001B618A /* main.m */,
-			);
-			path = LoginItemHelper;
-			sourceTree = "<group>";
-		};
-		6F7774DD217181B1006A79B3 /* UI */ = {
-			isa = PBXGroup;
-			children = (
-				6FB1BD5E21D2607A00A991BF /* macOS */,
-				6F7774DE217181B1006A79B3 /* iOS */,
-				6F628C3C217F09E9003482A3 /* TunnelViewModel.swift */,
-				6F8F0D7022258153000E8335 /* ActivateOnDemandViewModel.swift */,
-				6FBA103D21D6B6D70051C35F /* TunnelImporter.swift */,
-				6FBA103A21D6B4280051C35F /* ErrorPresenterProtocol.swift */,
-				6B62E45E220A6FA900EF34A6 /* PrivateDataConfirmation.swift */,
-				6F907C9B224663A2003CED21 /* LogViewHelper.swift */,
-			);
-			path = UI;
-			sourceTree = "<group>";
-		};
-		6F7774DE217181B1006A79B3 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				6FF4AC1E211EC472002C96EB /* Assets.xcassets */,
-				6FF4AC20211EC472002C96EB /* LaunchScreen.storyboard */,
-				5F4541A721C44F5B00994C13 /* View */,
-				5F4541AC21C4720B00994C13 /* ViewController */,
-				6F7774E0217181B1006A79B3 /* AppDelegate.swift */,
-				6F919EC2218A2AE90023B400 /* ErrorPresenter.swift */,
-				6F19D30322402B8700A126F2 /* ConfirmationAlertPresenter.swift */,
-				5F45417C21C1B23600994C13 /* UITableViewCell+Reuse.swift */,
-				6F29A9422278518D00DC6A6B /* RecentTunnelsTracker.swift */,
-				6F29A94622787B1600DC6A6B /* QuickActionItem.swift */,
-				6FF4AC23211EC472002C96EB /* Info.plist */,
-				6FF4AC482120B9E0002C96EB /* WireGuard.entitlements */,
-			);
-			path = iOS;
-			sourceTree = "<group>";
-		};
-		6F7774E6217201E0006A79B3 /* Model */ = {
-			isa = PBXGroup;
-			children = (
-				5F9696AF21CD7128008063FE /* TunnelConfiguration+WgQuickConfig.swift */,
-				6FFA5D942194454A0001E2F7 /* NETunnelProviderProtocol+Extension.swift */,
-				5F4541B121CBFAEE00994C13 /* String+ArrayConversion.swift */,
-			);
-			path = Model;
-			sourceTree = "<group>";
-		};
-		6F7774ED21722D0C006A79B3 /* Tunnel */ = {
-			isa = PBXGroup;
-			children = (
-				6F7774EE21722D97006A79B3 /* TunnelsManager.swift */,
-				6B707D8321F918D4000A8F73 /* TunnelConfiguration+UapiConfig.swift */,
-				6FFA5DA32197085D0001E2F7 /* ActivateOnDemandOption.swift */,
-				5F4541A821C451D100994C13 /* TunnelStatus.swift */,
-				6FB1017821C57DE600766195 /* MockTunnels.swift */,
-				6F7F7E5E21C7D74B00527607 /* TunnelErrors.swift */,
-			);
-			path = Tunnel;
-			sourceTree = "<group>";
-		};
-		6F919ED3218C65C50023B400 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				4E5C5B932BA6367F00082DED /* PrivacyInfo.xcprivacy */,
-				6F919ED4218C65C50023B400 /* DocumentIcons */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		6F919ED4218C65C50023B400 /* DocumentIcons */ = {
-			isa = PBXGroup;
-			children = (
-				6F919ED5218C65C50023B400 /* wireguard_doc_logo_22x29.png */,
-				6F919ED6218C65C50023B400 /* wireguard_doc_logo_44x58.png */,
-				6F919ED7218C65C50023B400 /* wireguard_doc_logo_64x64.png */,
-				6F919ED8218C65C50023B400 /* wireguard_doc_logo_320x320.png */,
-			);
-			path = DocumentIcons;
-			sourceTree = "<group>";
-		};
-		6FB1BD5E21D2607A00A991BF /* macOS */ = {
-			isa = PBXGroup;
-			children = (
-				6F70E22A22106A2D008BDFB4 /* LoginItemHelper */,
-				6F4DD16921DA556600690EAE /* View */,
-				6FBA104421D7EA750051C35F /* ViewController */,
-				6FBA101321D613F30051C35F /* Application.swift */,
-				6FB1BD5F21D2607A00A991BF /* AppDelegate.swift */,
-				6F89E17921EDEB0E00C97BB9 /* StatusItemController.swift */,
-				6FBA101621D655340051C35F /* StatusMenu.swift */,
-				6F3E02E8228000F6001FE7E3 /* MainMenu.swift */,
-				6F89E17B21F090CC00C97BB9 /* TunnelsTracker.swift */,
-				6FBA104121D6BC210051C35F /* ErrorPresenter.swift */,
-				6FCD99AE21E0EA1700BA4C82 /* ImportPanelPresenter.swift */,
-				6F2449E7226587B80047B9E9 /* MacAppStoreUpdateDetector.swift */,
-				6F6483E6229293300075BA15 /* LaunchedAtLoginDetector.swift */,
-				6FB1BD6121D2607E00A991BF /* Assets.xcassets */,
-				6FB1BD6621D2607E00A991BF /* Info.plist */,
-				6FB1BD6721D2607E00A991BF /* WireGuard.entitlements */,
-				6F4DD16721DA552B00690EAE /* NSTableView+Reuse.swift */,
-				5F52D0BE21E3788900283CEA /* NSColor+Hex.swift */,
-				6FFACD1E21E4D89600E9A2A5 /* ParseError+WireGuardAppError.swift */,
-			);
-			path = macOS;
-			sourceTree = "<group>";
-		};
-		6FBA104421D7EA750051C35F /* ViewController */ = {
-			isa = PBXGroup;
-			children = (
-				6FBA104521D7EBFA0051C35F /* TunnelsListTableViewController.swift */,
-				6F4DD16D21DBEA0700690EAE /* ManageTunnelsRootViewController.swift */,
-				6FDB3C3A21DCF47400A0C0BF /* TunnelDetailTableViewController.swift */,
-				6FCD99A821E0E0C700BA4C82 /* ButtonedDetailViewController.swift */,
-				6FCD99B021E0EDA900BA4C82 /* TunnelEditViewController.swift */,
-				6FDB6D12224A15BE00EE4BC3 /* LogViewController.swift */,
-				6FADE96A2254A6C200B838A4 /* UnusableTunnelDetailViewController.swift */,
-			);
-			path = ViewController;
-			sourceTree = "<group>";
-		};
-		6FDEF7E72186320E00D8FBF6 /* ZipArchive */ = {
-			isa = PBXGroup;
-			children = (
-				6FE254FA219C10800028284D /* ZipImporter.swift */,
-				6FE254FE219C60290028284D /* ZipExporter.swift */,
-				6FDEF801218646B900D8FBF6 /* ZipArchive.swift */,
-				6FDEF7F421863B6100D8FBF6 /* 3rdparty */,
-			);
-			path = ZipArchive;
-			sourceTree = "<group>";
-		};
-		6FDEF7F421863B6100D8FBF6 /* 3rdparty */ = {
-			isa = PBXGroup;
-			children = (
-				6FDEF7F521863B6100D8FBF6 /* minizip */,
-			);
-			path = 3rdparty;
-			sourceTree = "<group>";
-		};
-		6FDEF7F521863B6100D8FBF6 /* minizip */ = {
-			isa = PBXGroup;
-			children = (
-				6FDEF7FF21863C0100D8FBF6 /* ioapi.c */,
-				6FDEF7FE21863C0100D8FBF6 /* ioapi.h */,
-				6FDEF7F621863B6100D8FBF6 /* unzip.c */,
-				6FDEF7FA21863B6100D8FBF6 /* unzip.h */,
-				6FDEF7F721863B6100D8FBF6 /* zip.c */,
-				6FDEF7F921863B6100D8FBF6 /* zip.h */,
-			);
-			path = minizip;
-			sourceTree = "<group>";
-		};
-		6FF3526A21C23F720008484E /* Logging */ = {
-			isa = PBXGroup;
-			children = (
-				6FF3526C21C23F960008484E /* ringlogger.c */,
-				6FF3526B21C23F960008484E /* ringlogger.h */,
-				6FF3526E21C23FA10008484E /* Logger.swift */,
-			);
-			path = Logging;
-			sourceTree = "<group>";
-		};
 		6FF4AC0B211EC46F002C96EB = {
 			isa = PBXGroup;
 			children = (
-				4E29B1C22BC1222C00824F53 /* InfoPlist.xcstrings */,
-				4E9BD26E2BC12AAB00D71616 /* Localizable.xcstrings */,
-				6F5D0C432183B4A4000F85AD /* Shared */,
-				6FF4AC16211EC46F002C96EB /* WireGuardApp */,
-				6F5D0C1B218352EF000F85AD /* WireGuardNetworkExtension */,
-				585B10452577E293004F691E /* WireGuardKit */,
-				585B10532577E293004F691E /* WireGuardKitC */,
+				0A1D2029301905B300A51D75 /* Shared */,
+				0A1D22F53019071B00A51D75 /* WireGuardApp */,
+				0A1D20B33019062000A51D75 /* WireGuardNetworkExtension */,
+				0A1D20713019061300A51D75 /* WireGuardKit */,
+				0A1D205B3019061300A51D75 /* WireGuardKitC */,
 				6FF4AC15211EC46F002C96EB /* Products */,
 				6FF4AC452120B9E0002C96EB /* Frameworks */,
 			);
@@ -781,23 +403,6 @@
 				6F70E22922106A2D008BDFB4 /* WireGuardLoginItemHelper.app */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		6FF4AC16211EC46F002C96EB /* WireGuardApp */ = {
-			isa = PBXGroup;
-			children = (
-				6F919ED3218C65C50023B400 /* Resources */,
-				6F7774DD217181B1006A79B3 /* UI */,
-				6F7774ED21722D0C006A79B3 /* Tunnel */,
-				6FDEF7E72186320E00D8FBF6 /* ZipArchive */,
-				6F61F1E821B932F700483816 /* WireGuardAppError.swift */,
-				6F61F1EA21B937EF00483816 /* WireGuardResult.swift */,
-				6FE1765921C90E87002690EA /* LocalizationHelper.swift */,
-				6FF4AC2B211EC776002C96EB /* Config.xcconfig */,
-				6F689999218043390012E523 /* WireGuard-Bridging-Header.h */,
-			);
-			name = WireGuardApp;
-			path = Sources/WireGuardApp;
 			sourceTree = "<group>";
 		};
 		6FF4AC452120B9E0002C96EB /* Frameworks */ = {
@@ -859,6 +464,10 @@
 			dependencies = (
 				6FDEF7E221846C0000D8FBF6 /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				0A1D2029301905B300A51D75 /* Shared */,
+				0A1D20713019061300A51D75 /* WireGuardKit */,
+			);
 			name = WireGuardNetworkExtensioniOS;
 			packageProductDependencies = (
 			);
@@ -900,6 +509,10 @@
 				6F70E23B22109DD3008BDFB4 /* PBXTargetDependency */,
 				6FB1BD9821D4BFE700A991BF /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				0A1D2029301905B300A51D75 /* Shared */,
+				0A1D20713019061300A51D75 /* WireGuardKit */,
+			);
 			name = WireGuardmacOS;
 			packageProductDependencies = (
 			);
@@ -920,6 +533,10 @@
 			);
 			dependencies = (
 				6FB1BD9F21D4DF7A00A991BF /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				0A1D2029301905B300A51D75 /* Shared */,
+				0A1D20713019061300A51D75 /* WireGuardKit */,
 			);
 			name = WireGuardNetworkExtensionmacOS;
 			packageProductDependencies = (
@@ -944,6 +561,11 @@
 			);
 			dependencies = (
 				6F5D0C21218352EF000F85AD /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				0A1D2029301905B300A51D75 /* Shared */,
+				0A1D20713019061300A51D75 /* WireGuardKit */,
+				0A1D22F53019071B00A51D75 /* WireGuardApp */,
 			);
 			name = WireGuardiOS;
 			packageProductDependencies = (
@@ -1019,7 +641,6 @@
 				};
 			};
 			buildConfigurationList = 6FF4AC0F211EC46F002C96EB /* Build configuration list for PBXProject "WireGuard" */;
-			compatibilityVersion = "Xcode 10.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -1047,6 +668,7 @@
 			mainGroup = 6FF4AC0B211EC46F002C96EB;
 			packageReferences = (
 			);
+			preferredProjectObjectVersion = 51;
 			productRefGroup = 6FF4AC15211EC46F002C96EB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1067,7 +689,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4E5C5B962BA636B300082DED /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1075,8 +696,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4E9BD2702BC12AAB00D71616 /* Localizable.xcstrings in Resources */,
-				6FB1BD6221D2607E00A991BF /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1091,15 +710,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4E29B1C32BC1222C00824F53 /* InfoPlist.xcstrings in Resources */,
-				6F919ED9218C65C50023B400 /* wireguard_doc_logo_22x29.png in Resources */,
-				4E5C5B942BA6367F00082DED /* PrivacyInfo.xcprivacy in Resources */,
-				6FF4AC22211EC472002C96EB /* LaunchScreen.storyboard in Resources */,
-				6F919EDA218C65C50023B400 /* wireguard_doc_logo_44x58.png in Resources */,
-				4E9BD26F2BC12AAB00D71616 /* Localizable.xcstrings in Resources */,
-				6FF4AC1F211EC472002C96EB /* Assets.xcassets in Resources */,
-				6F919EDB218C65C50023B400 /* wireguard_doc_logo_64x64.png in Resources */,
-				6F919EDC218C65C50023B400 /* wireguard_doc_logo_320x320.png in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1257,30 +867,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6FF3527021C240160008484E /* ringlogger.c in Sources */,
-				585B106F2577E294004F691E /* WireGuardAdapter.swift in Sources */,
-				6FF3527121C240160008484E /* Logger.swift in Sources */,
-				6F5A2B4621AFDED40081EDD8 /* FileManager+Extension.swift in Sources */,
-				585B10772577E294004F691E /* DNSResolver.swift in Sources */,
-				585B10872577E294004F691E /* IPAddressRange.swift in Sources */,
-				6FFA5DA021958ECC0001E2F7 /* ErrorNotifier.swift in Sources */,
-				5F9696B121CD7128008063FE /* TunnelConfiguration+WgQuickConfig.swift in Sources */,
-				585B10832577E294004F691E /* PacketTunnelSettingsGenerator.swift in Sources */,
-				585B105F2577E293004F691E /* PeerConfiguration.swift in Sources */,
-				585B107F2577E294004F691E /* PrivateKey.swift in Sources */,
-				585B10672577E294004F691E /* TunnelConfiguration.swift in Sources */,
-				585B108F2577E294004F691E /* x25519.c in Sources */,
-				5CC6A71F2EE8F866008D120D /* HandshakeFreshnessEvaluator.swift in Sources */,
-				6B5C5E28220A48D30024272E /* Keychain.swift in Sources */,
-				585B10932577E294004F691E /* key.c in Sources */,
-				585B105B2577E293004F691E /* InterfaceConfiguration.swift in Sources */,
-				585B107B2577E294004F691E /* IPAddress+AddrInfo.swift in Sources */,
-				6FFA5D96219446380001E2F7 /* NETunnelProviderProtocol+Extension.swift in Sources */,
-				5F9696AE21CD6F72008063FE /* String+ArrayConversion.swift in Sources */,
-				585B10632577E293004F691E /* DNSServer.swift in Sources */,
-				5892BFA025558288000E678D /* PacketTunnelProvider.swift in Sources */,
-				585B108B2577E294004F691E /* Endpoint.swift in Sources */,
-				585B10732577E294004F691E /* Array+ConcurrentMap.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1288,7 +874,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6B6956362211DA80001B618A /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1296,75 +881,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				58233BD02591F842002060A8 /* NotificationToken.swift in Sources */,
-				6FBA101521D613F90051C35F /* Application.swift in Sources */,
-				6FB1BDCC21D50F5300A991BF /* TunnelsManager.swift in Sources */,
-				6F8F0D7222258153000E8335 /* ActivateOnDemandViewModel.swift in Sources */,
-				6FB1BDCD21D50F5300A991BF /* ActivateOnDemandOption.swift in Sources */,
-				6FB1BDCE21D50F5300A991BF /* TunnelStatus.swift in Sources */,
-				6FB1BDD021D50F5300A991BF /* TunnelErrors.swift in Sources */,
-				6FB1BDD121D50F5300A991BF /* ZipImporter.swift in Sources */,
-				6FB1BDD221D50F5300A991BF /* ZipExporter.swift in Sources */,
-				585B10642577E294004F691E /* DNSServer.swift in Sources */,
-				585B108C2577E294004F691E /* Endpoint.swift in Sources */,
-				6FBA104621D7EBFA0051C35F /* TunnelsListTableViewController.swift in Sources */,
-				6FB1BDD321D50F5300A991BF /* ZipArchive.swift in Sources */,
-				6FB1BDD421D50F5300A991BF /* ioapi.c in Sources */,
-				6FDB3C3C21DCF6BB00A0C0BF /* TunnelViewModel.swift in Sources */,
-				6FDB6D13224A15BF00EE4BC3 /* LogViewController.swift in Sources */,
-				6B5C5E29220A48D30024272E /* Keychain.swift in Sources */,
-				6FCD99AF21E0EA1700BA4C82 /* ImportPanelPresenter.swift in Sources */,
-				6FB1BDD521D50F5300A991BF /* unzip.c in Sources */,
-				6FB1BDD621D50F5300A991BF /* zip.c in Sources */,
-				6FDB3C3B21DCF47400A0C0BF /* TunnelDetailTableViewController.swift in Sources */,
-				6FB1BDD721D50F5300A991BF /* WireGuardAppError.swift in Sources */,
-				5F52D0BD21E3785C00283CEA /* ConfTextStorage.swift in Sources */,
-				5F52D0C221E378C000283CEA /* highlighter.c in Sources */,
-				6F4DD16E21DBEA0700690EAE /* ManageTunnelsRootViewController.swift in Sources */,
-				6F4DD16C21DA558F00690EAE /* NSTableView+Reuse.swift in Sources */,
-				6FB1BDD821D50F5300A991BF /* WireGuardResult.swift in Sources */,
-				585B10902577E294004F691E /* x25519.c in Sources */,
-				6B707D8621F918D4000A8F73 /* TunnelConfiguration+UapiConfig.swift in Sources */,
-				6FB1BDD921D50F5300A991BF /* LocalizationHelper.swift in Sources */,
-				585B10602577E293004F691E /* PeerConfiguration.swift in Sources */,
-				6F89E17C21F090CC00C97BB9 /* TunnelsTracker.swift in Sources */,
-				6B62E460220A6FA900EF34A6 /* PrivateDataConfirmation.swift in Sources */,
-				6FCD99B121E0EDA900BA4C82 /* TunnelEditViewController.swift in Sources */,
-				5CC6A71C2EE8F866008D120D /* HandshakeFreshnessEvaluator.swift in Sources */,
-				6FB17946222FD5960018AE71 /* OnDemandWiFiControls.swift in Sources */,
-				585B10882577E294004F691E /* IPAddressRange.swift in Sources */,
-				6FB1BDBC21D50F0200A991BF /* ringlogger.c in Sources */,
-				6FB1BDBD21D50F0200A991BF /* ringlogger.h in Sources */,
-				6FBA103F21D6B6FF0051C35F /* TunnelImporter.swift in Sources */,
-				6F89E17A21EDEB0E00C97BB9 /* StatusItemController.swift in Sources */,
-				6F5EA59B223E58A8002B380A /* ButtonRow.swift in Sources */,
-				6F4DD16B21DA558800690EAE /* TunnelListRow.swift in Sources */,
-				6FDB6D15224CB2CE00EE4BC3 /* LogViewCell.swift in Sources */,
-				6FE3661D21F64F6B00F78C7D /* ConfTextColorTheme.swift in Sources */,
-				6F3E02E9228000F6001FE7E3 /* MainMenu.swift in Sources */,
-				5F52D0BF21E3788900283CEA /* NSColor+Hex.swift in Sources */,
-				6FB1BDBE21D50F0200A991BF /* Logger.swift in Sources */,
-				6F6483E7229293300075BA15 /* LaunchedAtLoginDetector.swift in Sources */,
-				6FB1BDBF21D50F0200A991BF /* TunnelConfiguration+WgQuickConfig.swift in Sources */,
-				6FADE96C2254B8C300B838A4 /* UnusableTunnelDetailViewController.swift in Sources */,
-				6FFACD2021E4D8D500E9A2A5 /* ParseError+WireGuardAppError.swift in Sources */,
-				6FB1BDC021D50F0200A991BF /* NETunnelProviderProtocol+Extension.swift in Sources */,
-				6F1075642258AE9800D78929 /* DeleteTunnelsConfirmationAlert.swift in Sources */,
-				6FBA101821D656000051C35F /* StatusMenu.swift in Sources */,
-				6F613D9B21DE33B8004B217A /* KeyValueRow.swift in Sources */,
-				585B10802577E294004F691E /* PrivateKey.swift in Sources */,
-				6FB1BDC121D50F0200A991BF /* String+ArrayConversion.swift in Sources */,
-				5F52D0BB21E3781B00283CEA /* ConfTextView.swift in Sources */,
-				6FBA104021D6B7040051C35F /* ErrorPresenterProtocol.swift in Sources */,
-				6FCD99AA21E0E14700BA4C82 /* ButtonedDetailViewController.swift in Sources */,
-				6FBA104321D6BC250051C35F /* ErrorPresenter.swift in Sources */,
-				6F2449E8226587B90047B9E9 /* MacAppStoreUpdateDetector.swift in Sources */,
-				585B105C2577E293004F691E /* InterfaceConfiguration.swift in Sources */,
-				6F907C9D224663A2003CED21 /* LogViewHelper.swift in Sources */,
-				6FB1BDC921D50F0300A991BF /* FileManager+Extension.swift in Sources */,
-				585B10942577E294004F691E /* key.c in Sources */,
-				585B10682577E294004F691E /* TunnelConfiguration.swift in Sources */,
-				6FB1BD6021D2607A00A991BF /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1372,30 +888,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6FB1BDB321D4F55700A991BF /* ErrorNotifier.swift in Sources */,
-				585B10712577E294004F691E /* WireGuardAdapter.swift in Sources */,
-				6FB1BDA221D4F53300A991BF /* ringlogger.c in Sources */,
-				6B5C5E2A220A48D30024272E /* Keychain.swift in Sources */,
-				585B10792577E294004F691E /* DNSResolver.swift in Sources */,
-				585B10892577E294004F691E /* IPAddressRange.swift in Sources */,
-				6FB1BDA421D4F53300A991BF /* Logger.swift in Sources */,
-				6FB1BDA521D4F53300A991BF /* TunnelConfiguration+WgQuickConfig.swift in Sources */,
-				585B10852577E294004F691E /* PacketTunnelSettingsGenerator.swift in Sources */,
-				585B10612577E293004F691E /* PeerConfiguration.swift in Sources */,
-				585B10812577E294004F691E /* PrivateKey.swift in Sources */,
-				585B10692577E294004F691E /* TunnelConfiguration.swift in Sources */,
-				585B10912577E294004F691E /* x25519.c in Sources */,
-				5CC6A71D2EE8F866008D120D /* HandshakeFreshnessEvaluator.swift in Sources */,
-				6FB1BDA621D4F53300A991BF /* NETunnelProviderProtocol+Extension.swift in Sources */,
-				585B10952577E294004F691E /* key.c in Sources */,
-				585B105D2577E293004F691E /* InterfaceConfiguration.swift in Sources */,
-				585B107D2577E294004F691E /* IPAddress+AddrInfo.swift in Sources */,
-				6FB1BDA721D4F53300A991BF /* String+ArrayConversion.swift in Sources */,
-				5892BFA125558288000E678D /* PacketTunnelProvider.swift in Sources */,
-				585B10652577E294004F691E /* DNSServer.swift in Sources */,
-				6FB1BDAF21D4F53300A991BF /* FileManager+Extension.swift in Sources */,
-				585B108D2577E294004F691E /* Endpoint.swift in Sources */,
-				585B10752577E294004F691E /* Array+ConcurrentMap.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1403,70 +895,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6FE1765A21C90E87002690EA /* LocalizationHelper.swift in Sources */,
-				6F29A94722787B1600DC6A6B /* QuickActionItem.swift in Sources */,
-				585B105A2577E293004F691E /* InterfaceConfiguration.swift in Sources */,
-				6FF3527221C2616C0008484E /* ringlogger.c in Sources */,
-				6F0F44CB222D55FD00B0FF04 /* EditableTextCell.swift in Sources */,
-				585B105E2577E293004F691E /* PeerConfiguration.swift in Sources */,
-				6FF3527321C2616C0008484E /* Logger.swift in Sources */,
-				6F7774E421718281006A79B3 /* TunnelsListTableViewController.swift in Sources */,
-				585B108E2577E294004F691E /* x25519.c in Sources */,
-				6F7774EF21722D97006A79B3 /* TunnelsManager.swift in Sources */,
-				5F45417D21C1B23600994C13 /* UITableViewCell+Reuse.swift in Sources */,
-				5F45419221C2D55800994C13 /* CheckmarkCell.swift in Sources */,
-				6FE254FF219C60290028284D /* ZipExporter.swift in Sources */,
-				6F8F0D7122258153000E8335 /* ActivateOnDemandViewModel.swift in Sources */,
-				6F8F0D7722267C57000E8335 /* SSIDOptionEditTableViewController.swift in Sources */,
-				585B10622577E293004F691E /* DNSServer.swift in Sources */,
-				6FDEF7E62185EFB200D8FBF6 /* QRScanViewController.swift in Sources */,
-				6FDB6D18224CC05A00EE4BC3 /* LogViewController.swift in Sources */,
-				6FFA5D952194454A0001E2F7 /* NETunnelProviderProtocol+Extension.swift in Sources */,
-				5F4541A921C451D100994C13 /* TunnelStatus.swift in Sources */,
-				6F8F0D7422267AD2000E8335 /* ChevronCell.swift in Sources */,
-				6F61F1E921B932F700483816 /* WireGuardAppError.swift in Sources */,
-				6F7774E2217181B1006A79B3 /* AppDelegate.swift in Sources */,
-				6FDEF80021863C0100D8FBF6 /* ioapi.c in Sources */,
-				6F7F7E5F21C7D74B00527607 /* TunnelErrors.swift in Sources */,
-				6FDEF7FC21863B6100D8FBF6 /* zip.c in Sources */,
-				6B5C5E27220A48D30024272E /* Keychain.swift in Sources */,
-				6F628C3D217F09E9003482A3 /* TunnelViewModel.swift in Sources */,
-				5F4541A621C4449E00994C13 /* ButtonCell.swift in Sources */,
-				5F45419821C2D60500994C13 /* KeyValueCell.swift in Sources */,
-				6FBA103E21D6B6D70051C35F /* TunnelImporter.swift in Sources */,
-				6F9B8A8E223398610041B9C4 /* SSIDOptionDetailTableViewController.swift in Sources */,
-				6F19D30422402B8700A126F2 /* ConfirmationAlertPresenter.swift in Sources */,
-				6F919EC3218A2AE90023B400 /* ErrorPresenter.swift in Sources */,
-				6B62E45F220A6FA900EF34A6 /* PrivateDataConfirmation.swift in Sources */,
-				6F5A2B4821AFF49A0081EDD8 /* FileManager+Extension.swift in Sources */,
-				5F45418C21C2D48200994C13 /* TunnelEditKeyValueCell.swift in Sources */,
-				6FE254FB219C10800028284D /* ZipImporter.swift in Sources */,
-				585B107E2577E294004F691E /* PrivateKey.swift in Sources */,
-				6FDEF7FB21863B6100D8FBF6 /* unzip.c in Sources */,
-				6F29A9432278518D00DC6A6B /* RecentTunnelsTracker.swift in Sources */,
-				6F0F44C9222D55BB00B0FF04 /* TextCell.swift in Sources */,
-				5F4541A021C2D6B700994C13 /* TunnelListCell.swift in Sources */,
-				5F9696B021CD7128008063FE /* TunnelConfiguration+WgQuickConfig.swift in Sources */,
-				6F628C41217F47DB003482A3 /* TunnelDetailTableViewController.swift in Sources */,
-				6F61F1EB21B937EF00483816 /* WireGuardResult.swift in Sources */,
-				6F7774F321774263006A79B3 /* TunnelEditTableViewController.swift in Sources */,
-				6FBA103B21D6B4290051C35F /* ErrorPresenterProtocol.swift in Sources */,
-				58233BCF2591F842002060A8 /* NotificationToken.swift in Sources */,
-				585B10862577E294004F691E /* IPAddressRange.swift in Sources */,
-				6FDEF802218646BA00D8FBF6 /* ZipArchive.swift in Sources */,
-				585B10922577E294004F691E /* key.c in Sources */,
-				5F45419021C2D53800994C13 /* SwitchCell.swift in Sources */,
-				5CC6A71E2EE8F866008D120D /* HandshakeFreshnessEvaluator.swift in Sources */,
-				6FB1017921C57DE600766195 /* MockTunnels.swift in Sources */,
-				6B707D8421F918D4000A8F73 /* TunnelConfiguration+UapiConfig.swift in Sources */,
-				6FDEF806218725D200D8FBF6 /* SettingsTableViewController.swift in Sources */,
-				5F4541A221C2D6DF00994C13 /* BorderedTextButton.swift in Sources */,
-				585B10662577E294004F691E /* TunnelConfiguration.swift in Sources */,
-				6F7774E1217181B1006A79B3 /* MainViewController.swift in Sources */,
-				6FFA5DA42197085D0001E2F7 /* ActivateOnDemandOption.swift in Sources */,
-				5F4541B221CBFAEE00994C13 /* String+ArrayConversion.swift in Sources */,
-				585B108A2577E294004F691E /* Endpoint.swift in Sources */,
-				6F907C9C224663A2003CED21 /* LogViewHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1499,18 +927,6 @@
 			targetProxy = 6FDEF7E121846C0000D8FBF6 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
-
-/* Begin PBXVariantGroup section */
-		6FF4AC20211EC472002C96EB /* LaunchScreen.storyboard */ = {
-			isa = PBXVariantGroup;
-			children = (
-				6FF4AC21211EC472002C96EB /* Base */,
-				4EC559AC2BC1250C00BBABBE /* mul */,
-			);
-			name = LaunchScreen.storyboard;
-			sourceTree = "<group>";
-		};
-/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		6F5D0C23218352EF000F85AD /* Debug */ = {
@@ -1709,7 +1125,8 @@
 		};
 		6FF4AC24211EC472002C96EB /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6FF4AC2B211EC776002C96EB /* Config.xcconfig */;
+			baseConfigurationReferenceAnchor = 0A1D22F53019071B00A51D75 /* WireGuardApp */;
+			baseConfigurationReferenceRelativePath = Config/Config.xcconfig;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1780,7 +1197,8 @@
 		};
 		6FF4AC25211EC472002C96EB /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6FF4AC2B211EC776002C96EB /* Config.xcconfig */;
+			baseConfigurationReferenceAnchor = 0A1D22F53019071B00A51D75 /* WireGuardApp */;
+			baseConfigurationReferenceRelativePath = Config/Config.xcconfig;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;


### PR DESCRIPTION
## 📝 Description

This PR migrates the project structure from traditional Xcode Groups to Folder References (Buildable Folders / File System Folders).
Previously, adding, moving, or deleting files required updating the .xcodeproj file, which frequently caused complex merge conflicts. Now, the project structure mirrors the actual file system.

## 🚀 Key Changes

* Removed Xcode Groups: Converted virtual groups into real file system directories.
* Folder References: Enabled automatic file syncing based on the disk structure.
* Cleaned .xcodeproj: Drastically reduced the size of the project file and eliminated source tree clutter.

## 💎 Benefits

* No more merge conflicts in .xcodeproj when adding or removing files.
* Single source of truth: The disk structure matches the Xcode navigator 1:1.
* Smoother code reviews and easier file management.
